### PR TITLE
Update CalTopo help redirect to point to FAQ instead of Google Doc

### DIFF
--- a/generate_redirects.py
+++ b/generate_redirects.py
@@ -6,7 +6,7 @@ def main():
     #   key   = source URL (the old URL you want to redirect from)
     #   value = destination URL (the new URL you want to redirect to)
     redirects = {
-        "/help/connect-eepilot-to-caltopo": "https://docs.google.com/document/d/1FWbQLkwrYZoAAg3zbsxEeG-DClcL04zU_dSvcRDk8OA/edit?tab=t.0#bookmark=id.xe2q49a0wdsn",
+        "/help/connect-eepilot-to-caltopo": "https://www.eagleeyessearch.com/faq/#connect-caltopo",
         "/help/pilot-tutorials": "/pilot#tutorials",
     }
     

--- a/redirects/help-connect-eepilot-to-caltopo.md
+++ b/redirects/help-connect-eepilot-to-caltopo.md
@@ -1,4 +1,4 @@
 ---
 permalink: /help/connect-eepilot-to-caltopo
-redirect_to: "https://docs.google.com/document/d/1FWbQLkwrYZoAAg3zbsxEeG-DClcL04zU_dSvcRDk8OA/edit?tab=t.0#bookmark=id.xe2q49a0wdsn"
+redirect_to: "https://www.eagleeyessearch.com/faq/#connect-caltopo"
 ---


### PR DESCRIPTION
Got an email from customer Jeffrey Burns that he wanted access to an FAQ draft google doc. Some obscure redirect to how to connect to caltopo from unknown location. - Changed redirected to website FAQ page.