### PR TITLE
Remove services and video pages from website navigation and sitemap

### DIFF
--- a/_includes/navbar-pages.html
+++ b/_includes/navbar-pages.html
@@ -5,9 +5,9 @@
     <li>
         <a href="{{ '/pricing/' | relative_url }}" class="no-page-fade">Pricing</a>
     </li>
-    <li>
+    <!-- <li>
         <a href="{{ '/services/' | relative_url }}" class="no-page-fade">Services</a>
-    </li>
+    </li> -->
     <li>
         <a href="{{ '/news/' | relative_url }}" class="no-page-fade">News</a>
     </li>

--- a/services.html
+++ b/services.html
@@ -1,3 +1,4 @@
+<!--
 ---
 layout: main
 title: Services
@@ -297,4 +298,5 @@ permalink: /services/
             behavior: 'smooth'
         });
     }
-</script> 
+</script>
+--> 

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -24,12 +24,12 @@
     <changefreq>daily</changefreq>
     <priority>0.9</priority>
   </url>
-  <url>
+  <!-- <url>
     <loc>https://www.eagleeyessearch.com/services/</loc>
     <lastmod>2025-04-17</lastmod>
     <changefreq>daily</changefreq>
     <priority>0.9</priority>
-  </url>
+  </url> -->
   <url>
     <loc>https://www.eagleeyessearch.com/pilot</loc>
     <lastmod>2025-04-17</lastmod>

--- a/video.html
+++ b/video.html
@@ -1,3 +1,4 @@
+<!--
 ---
 layout: main
 permalink: /video
@@ -59,4 +60,5 @@ permalink: /video
             </iframe>
         </div>
     </div>
+-->
 </div> 


### PR DESCRIPTION
Changes:
- Commented out Services link in navigation menu
- Commented out entire services.html file
- Commented out entire video.html file  
- Removed Services page from sitemap.xml

Result:
- Services and Video pages are no longer accessible to visitors
- Search engines won't index these pages
- Files are preserved for potential future use
- No broken links or navigation issues

Files modified:
- _includes/navbar-pages.html
- services.html
- sitemap.xml
- video.html