### PR TITLE
Improve Controller Setup card display

### DIFF
--- a/setup.html
+++ b/setup.html
@@ -1512,7 +1512,6 @@ function renderConfigDetails(cfg, uniqueId) {
     if (cfg.service_account) {
         if (cfg.service_account.title) html += '<div><strong>Service Account:</strong> ' + escapeHtml(cfg.service_account.title) + '</div>';
         if (cfg.service_account.teamName) html += '<div><strong>CalTopo Team:</strong> ' + escapeHtml(cfg.service_account.teamName) + '</div>';
-        if (cfg.service_account.permission) html += '<div><strong>Permission:</strong> ' + escapeHtml(cfg.service_account.permission) + '</div>';
     }
     if (cfg.default_map && cfg.default_map.mapName) html += '<div><strong>Default Map:</strong> ' + escapeHtml(cfg.default_map.mapName) + '</div>';
     if (cfg.procedures_text) {

--- a/setup.html
+++ b/setup.html
@@ -1507,11 +1507,9 @@ function renderConfigList(configs) {
 
 function renderConfigDetails(cfg, uniqueId) {
     var html = '';
-    if (cfg.units) html += '<div><strong>Units:</strong> ' + (cfg.units === 'METRIC' ? 'Metric (m, km/h)' : 'US / Imperial (ft, mph)') + '</div>';
-    if (cfg.coordsys) html += '<div><strong>Coordinates:</strong> ' + escapeHtml(cfg.coordsys) + '</div>';
     if (cfg.service_account) {
-        if (cfg.service_account.title) html += '<div><strong>Service Account:</strong> ' + escapeHtml(cfg.service_account.title) + '</div>';
         if (cfg.service_account.teamName) html += '<div><strong>CalTopo Team:</strong> ' + escapeHtml(cfg.service_account.teamName) + '</div>';
+        if (cfg.service_account.title) html += '<div><strong>Service Account:</strong> ' + escapeHtml(cfg.service_account.title) + '</div>';
     }
     if (cfg.default_map && cfg.default_map.mapName) html += '<div><strong>Default Map:</strong> ' + escapeHtml(cfg.default_map.mapName) + '</div>';
     if (cfg.procedures_text) {
@@ -1528,6 +1526,8 @@ function renderConfigDetails(cfg, uniqueId) {
         }
     }
     if (cfg.procedures_link) html += '<div><strong>Procedures Link:</strong> <a href="' + escapeHtml(cfg.procedures_link) + '" target="_blank" onclick="event.stopPropagation();" style="color: #1e90ff; word-break: break-all;">' + escapeHtml(cfg.procedures_link) + '</a></div>';
+    if (cfg.units) html += '<div><strong>Units:</strong> ' + (cfg.units === 'METRIC' ? 'Metric (m, km/h)' : 'US / Imperial (ft, mph)') + '</div>';
+    if (cfg.coordsys) html += '<div><strong>Coordinates:</strong> ' + escapeHtml(cfg.coordsys) + '</div>';
     return html;
 }
 

--- a/setup.html
+++ b/setup.html
@@ -1321,7 +1321,7 @@ function showIntroScreen(configs) {
         skipBtn.style.display = 'none';
     } else if (configs && configs.length > 0) {
         titleEl.textContent = 'Controller Setup available';
-        messageEl.textContent = 'Your team already has a Controller Setup. Select one to apply it to the device that was just activated, or create a new one.';
+        messageEl.textContent = 'Select a Controller Setup from the list below, or create a new one.';
         setupBtn.textContent = 'Create New';
         setupBtn.style.display = '';
         skipBtn.style.display = '';


### PR DESCRIPTION
## Summary
- Show config card contents inline without dropdowns — all details visible immediately
- Reorder details: CalTopo team, default map, procedures on top; units/coordinates below
- Remove permission level from cards
- Procedures text shows first line with "Show more" toggle for longer content
- Update intro screen message text

## Test plan
- [ ] Verify config cards show details inline on mobile and desktop
- [ ] Test "Show more" / "Show less" on multi-line procedures
- [ ] Verify field ordering: CalTopo → map → procedures → units → coordinates

🤖 Generated with [Claude Code](https://claude.com/claude-code)