### PR TITLE
Hide activation stepper during license picker

### DIFF
--- a/setup.html
+++ b/setup.html
@@ -1615,6 +1615,7 @@ var lpSelectedLicense = null;
 
 function showLicensePicker() {
     document.getElementById('licensePickerSection').style.display = 'block';
+    document.getElementById('wizardStepper').style.display = 'none';
     document.getElementById('setupIntro').style.display = 'none';
     document.getElementById('setupConfigList').style.display = 'none';
     document.getElementById('setupForm').style.display = 'none';


### PR DESCRIPTION
The wizard stepper showed "Activate ✓" before the user had actually selected a license. Hide it in showLicensePicker and only show it after complete_activation succeeds.