### PR TITLE
Add /caltopo/ page and unified /setup/ flow

### DIFF
--- a/setup.html
+++ b/setup.html
@@ -2347,17 +2347,7 @@ function showConfigForm() {
     document.getElementById('licensePickerSection').style.display = 'none';
 
     document.getElementById('setupForm').style.display = 'block';
-
-    if (isMobileDevice()) {
-        // Mobile: step-by-step wizard
-        showFormStep(1);
-        showCtSubStep(0);
-        document.getElementById('formStepIndicator').style.display = '';
-        document.getElementById('formBottomActions').style.display = 'none';
-    } else {
-        // Laptop/desktop: show all sections at once
-        showAllFormSteps();
-    }
+    showAllFormSteps();
 }
 
 function showAllFormSteps() {


### PR DESCRIPTION
## Summary
- Add standalone `/caltopo/` page for CalTopo service account setup (no auth, App Check gated). Generates QR code + JSON download in the scan2v2 format.
- Unify `/setup/` to handle both license activation and controller config. Supports bare `session_id` URLs (new Android contract) with auto-fetch from `get_activation_request`.
- Add license picker to `/setup/` for activation flows without a pre-selected license.
- Single-page form layout on both mobile and desktop: Name + Units always visible, CalTopo and Procedures as collapsible toggles.
- CalTopo section shows "Connected" summary with live map dropdown when a service account exists, or handoff to `/caltopo/` on mobile.
- Read `setup_type` URL param as belt-and-suspenders for backend `setup_type` field.
- Remove dead Tesseract OCR camera scanner (~150 lines).
- Visual polish: card-style config list, section cards in edit form, button hierarchy, hover effects.

## Test plan
- [ ] `/setup/?session_id=...` (no license_id) — auto-fetches activation request, shows license picker, stepper hidden until activation completes
- [ ] `/setup/?session_id=...&setup_type=caltopo` — single-step CalTopo-only mode
- [ ] `/setup/` direct access — config list with edit/delete, single-page form with toggles
- [ ] `/caltopo/` — all instructions on one page, verify & connect produces QR + JSON download
- [ ] Mobile: same single-page form, CalTopo toggle shows handoff to `/caltopo/` + QR scanner
- [ ] Legacy `/activate/` URLs still work unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)