### PR TITLE
Restore complete_activation in license picker for two-stage flow

### DIFF
--- a/setup.html
+++ b/setup.html
@@ -1780,14 +1780,18 @@ async function lpConfirmActivation() {
         document.getElementById('setupLicenseDisplay').textContent = currentLicenseId;
         document.getElementById('setupLicenseInfo').style.display = '';
 
+        // Always call complete_activation so the app gets the license_key
+        // and transitions from "Waiting for activation" to the next state.
+        // When enableSetup=true, the app sees completed + no configuration
+        // and shows "Waiting for Controller Setup..." until we write the config later.
+        await apiCall('complete_activation', {
+            session_id: urlSessionId,
+            license_id: currentLicenseId
+        });
+
         document.getElementById('licensePickerSection').style.display = 'none';
 
         if (!enableSetup) {
-            // No setup needed — complete activation now and show success
-            await apiCall('complete_activation', {
-                session_id: urlSessionId,
-                license_id: currentLicenseId
-            });
             showActivationOnlySuccess();
         } else if (singleStepMode) {
             document.getElementById('wizardStepper').style.display = 'flex';


### PR DESCRIPTION
The app needs complete_activation to be called after license selection so it gets the license_key and transitions from "Waiting for activation" to "Waiting for Controller Setup". The earlier removal caused the app to stay stuck on the activation screen.

The two-stage flow now works:
1. License pick → complete_activation (sets license_key, no configuration) → app shows "Waiting for Controller Setup..."
2. User finishes wizard → set_activation_configuration_endpoint (writes config) → app sees configuration, applies it, dismisses

The app won't finish early because saveCurrentStep writes to the config store but NOT to the activation session — only the final saveConfiguration and introSelectConfig call set_activation_configuration_endpoint.