### PR TITLE
Improve CalTopo toggle: keep page open + clearer button hints

### DIFF
--- a/setup.html
+++ b/setup.html
@@ -1187,17 +1187,18 @@ permalink: /setup/
                 <!-- Folds out inside the same container when checked: no account yet -->
                 <div id="ctNoAccount" style="display: none; margin-top: 1rem; padding-top: 0.75rem; border-top: 1px solid #dee2e6;" onclick="event.stopPropagation();">
                     <p style="font-size: 1.5rem; color: #333; margin: 0 0 0.75rem; line-height: 1.6;">A CalTopo service account keeps your controller permanently connected to CalTopo, so you don't have to log in manually every few days.</p>
-                    <p style="font-size: 1.5rem; color: #333; margin: 0 0 0.75rem; line-height: 1.6;">We recommend setting this up on a laptop or desktop. Go to:<br><a href="{{ '/caltopo/' | relative_url }}" target="_blank" style="color: #1e90ff; text-decoration: none; font-weight: 700; font-size: 1.6rem;">EagleEyesSearch.com/caltopo</a></p>
-                    <p style="font-size: 1.5rem; color: #333; margin: 0 0 1rem; line-height: 1.6;">After completing the form, you can transfer the credentials to your controller:</p>
+                    <p style="font-size: 1.5rem; color: #333; margin: 0 0 0.75rem; line-height: 1.6;"><strong>Keep this page open.</strong> In a new browser window, go to:</p>
+                    <div style="margin-bottom: 1rem;"><a href="{{ '/caltopo/' | relative_url }}" target="_blank" style="color: #1e90ff; text-decoration: none; font-weight: 700; font-size: 1.7rem;">EagleEyesSearch.com/caltopo</a></div>
+                    <p style="font-size: 1.5rem; color: #333; margin: 0 0 1rem; line-height: 1.6;">Once you've completed the setup there, come back here to transfer the credentials:</p>
 
                     <div style="display: flex; flex-wrap: wrap; gap: 1rem; margin-top: 0.5rem;">
                         <div style="flex: 1; min-width: 200px; text-align: center;">
                             <button class="setup-btn setup-btn-primary" onclick="openCaltopoQrScanner()" style="width: 100%;">Scan QR Code</button>
-                            <div style="font-size: 1.2rem; color: #888; margin-top: 0.3rem;">Use your phone's camera</div>
+                            <div style="font-size: 1.2rem; color: #888; margin-top: 0.4rem;">I'm on my phone — scan the QR code from my laptop screen</div>
                         </div>
                         <div style="flex: 1; min-width: 200px; text-align: center;">
-                            <button class="setup-btn setup-btn-outline" onclick="showCtPasteDialog()" style="width: 100%;">Paste credentials</button>
-                            <div style="font-size: 1.2rem; color: #888; margin-top: 0.3rem;">If you set up CalTopo on this computer</div>
+                            <button class="setup-btn setup-btn-outline" onclick="showCtPasteDialog()" style="width: 100%;">Paste Credentials</button>
+                            <div style="font-size: 1.2rem; color: #888; margin-top: 0.4rem;">I set up CalTopo on this computer</div>
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
Rewrite the no-account text to tell users to keep the setup page open, show the URL on its own line, and reframe the two transfer buttons with first-person context hints.