### PR TITLE
CalTopo page polish + setup.html squared borders

### DIFF
--- a/caltopo.html
+++ b/caltopo.html
@@ -59,7 +59,7 @@ noindex: true
     }
     .ct-header {
         text-align: center;
-        margin-bottom: 2.5rem;
+        margin-bottom: 3.5rem;
     }
     .ct-header h1 {
         font-size: 2.4rem;

--- a/caltopo.html
+++ b/caltopo.html
@@ -238,13 +238,13 @@ noindex: true
 <div class="ct-container">
     <div class="ct-header">
         <h1>CalTopo Service Account Setup</h1>
-        <p>Create a CalTopo service account so Eagle Eyes stays permanently connected.</p>
+        <p>Create a CalTopo service account so Eagle Eyes apps can stay permanently connected to CalTopo without needing to log in again.</p>
     </div>
 
     <!-- Instructions -->
     <div class="ct-section">
         <h2>Step 1: Create a Service Account in CalTopo</h2>
-        <p>Open a new browser window and put it side by side with this one so you can easily switch back and forth.<br>In the new browser window, go to <a href="https://caltopo.com/" target="_blank" rel="noopener" style="color: #1e90ff; font-weight: 500;">caltopo.com</a> and sign in. You'll need <strong>admin access</strong> to your team. Then:</p>
+        <p>To set up a service account, you will need admin access to your CalTopo Teams account.<br>Open a new browser window and go to <a href="https://caltopo.com/" target="_blank" rel="noopener" style="color: #1e90ff; font-weight: 500;">caltopo.com</a>. Put it side by side with this one so you can easily switch back and forth. Then:</p>
         <div class="ct-instructions-layout" style="display: flex; gap: 2rem; align-items: flex-start;">
             <div style="flex: 1;">
                 <ol>

--- a/caltopo.html
+++ b/caltopo.html
@@ -255,7 +255,7 @@ noindex: true
                     <li>Enter a title (e.g. "Eagle Eyes"), make sure <strong>Update</strong> is selected as the permission, then click <strong>Create</strong></li>
                 </ol>
             </div>
-            <div class="ct-screenshot" style="flex-shrink: 0; width: 360px; margin-top: 10px;">
+            <div class="ct-screenshot" style="flex-shrink: 0; width: 345px; margin-top: 10px;">
                 <img src="{{ '/images/caltopo-create-service-account.png' | relative_url }}" alt="CalTopo Create Service Account dialog" style="width: 100%; border-radius: 8px; border: 1px solid #ddd;">
             </div>
         </div>

--- a/caltopo.html
+++ b/caltopo.html
@@ -255,7 +255,7 @@ noindex: true
                     <li>Enter a title (e.g. "Eagle Eyes"), make sure <strong>Update</strong> is selected as the permission, then click <strong>Create</strong></li>
                 </ol>
             </div>
-            <div class="ct-screenshot" style="flex-shrink: 0; width: 345px; margin-top: 10px;">
+            <div class="ct-screenshot" style="flex-shrink: 0; width: 390px; margin-top: 10px;">
                 <img src="{{ '/images/caltopo-create-service-account.png' | relative_url }}" alt="CalTopo Create Service Account dialog" style="width: 100%; border-radius: 8px; border: 1px solid #ddd;">
             </div>
         </div>

--- a/caltopo.html
+++ b/caltopo.html
@@ -255,7 +255,7 @@ noindex: true
                     <li>Enter a title (e.g. "Eagle Eyes"), make sure <strong>Update</strong> is selected as the permission, then click <strong>Create</strong></li>
                 </ol>
             </div>
-            <div class="ct-screenshot" style="flex-shrink: 0; width: 300px;">
+            <div class="ct-screenshot" style="flex-shrink: 0; width: 360px; margin-top: 10px;">
                 <img src="{{ '/images/caltopo-create-service-account.png' | relative_url }}" alt="CalTopo Create Service Account dialog" style="width: 100%; border-radius: 8px; border: 1px solid #ddd;">
             </div>
         </div>

--- a/caltopo.html
+++ b/caltopo.html
@@ -243,7 +243,7 @@ noindex: true
 
     <!-- Instructions -->
     <div class="ct-section">
-        <h2>Create a Service Account in CalTopo</h2>
+        <h2>Step 1: Create a Service Account in CalTopo</h2>
         <p>Open a new browser window and put it side by side with this one so you can easily switch back and forth.<br>In the new browser window, go to <a href="https://caltopo.com/" target="_blank" rel="noopener" style="color: #1e90ff; font-weight: 500;">caltopo.com</a> and sign in. You'll need <strong>admin access</strong> to your team. Then:</p>
         <div class="ct-instructions-layout" style="display: flex; gap: 2rem; align-items: flex-start;">
             <div style="flex: 1;">
@@ -263,7 +263,7 @@ noindex: true
 
     <!-- Credential fields -->
     <div class="ct-section">
-        <h2>Enter the Credentials</h2>
+        <h2>Step 2: Enter the Credentials</h2>
 
         <div class="ct-field">
             <label for="ctSecret">Credential Secret</label>
@@ -287,6 +287,7 @@ noindex: true
 
     <!-- Verify button -->
     <div style="text-align: center; margin-bottom: 2rem;">
+        <p style="font-size: 1.35rem; color: #777; margin-bottom: 1rem;">Once all three credential fields are filled and show a checkmark, press the button below to verify they work.</p>
         <button class="ct-btn" id="ctVerifyBtn" onclick="ctVerify()" disabled>Verify &amp; Connect</button>
         <div class="ct-status" id="ctVerifyStatus"></div>
     </div>

--- a/caltopo.html
+++ b/caltopo.html
@@ -285,8 +285,6 @@ noindex: true
         </div>
     </div>
 
-    <hr class="ct-divider">
-
     <!-- Verify button -->
     <div style="text-align: center; margin-bottom: 2rem;">
         <button class="ct-btn" id="ctVerifyBtn" onclick="ctVerify()" disabled>Verify &amp; Connect</button>

--- a/caltopo.html
+++ b/caltopo.html
@@ -59,7 +59,7 @@ noindex: true
     }
     .ct-header {
         text-align: center;
-        margin-bottom: 1.5rem;
+        margin-bottom: 2.5rem;
     }
     .ct-header h1 {
         font-size: 2.4rem;

--- a/setup.html
+++ b/setup.html
@@ -97,7 +97,7 @@ noindex: true
     .setup-form.form-mode .form-step {
         background: #f8f9fa;
         border: 1px solid #e9ecef;
-        border-radius: 8px;
+        border-radius: 4px;
         padding: 1.5rem 1.5rem;
         margin-bottom: 1.5rem;
     }
@@ -121,7 +121,7 @@ noindex: true
     .setup-form.form-mode .setup-field input,
     .setup-form.form-mode .setup-field select,
     .setup-form.form-mode .setup-field textarea {
-        border-radius: 8px;
+        border-radius: 4px;
         border: 1px solid #dee2e6;
         padding: 12px 14px;
         font-size: 1.6rem;
@@ -143,7 +143,7 @@ noindex: true
         padding: 1rem 1.25rem;
         background: #f8f9fa;
         border: 1px solid #e9ecef;
-        border-radius: 8px;
+        border-radius: 4px;
         cursor: pointer;
         margin-bottom: 1.5rem;
         transition: background 0.2s, border-color 0.2s;
@@ -334,7 +334,7 @@ noindex: true
     }
     .lp-primary-card {
         border: 2px solid #1e90ff;
-        border-radius: 8px;
+        border-radius: 4px;
         background: #f0f7ff;
         padding: 16px;
         text-align: left;
@@ -572,7 +572,7 @@ noindex: true
     .setup-section {
         background: white;
         border: 2px solid #e9ecef;
-        border-radius: 12px;
+        border-radius: 6px;
         padding: 2rem;
         margin-bottom: 2rem;
         box-shadow: 0 4px 12px rgba(0, 0, 0, 0.06);
@@ -601,7 +601,7 @@ noindex: true
     /* CalTopo instructions */
     .caltopo-instructions {
         background: #f8f9fa;
-        border-radius: 8px;
+        border-radius: 4px;
         padding: 1.2rem 1.5rem;
         margin-bottom: 1.5rem;
         font-size: 1.5rem;
@@ -621,7 +621,7 @@ noindex: true
     /* CalTopo verify result box */
     .caltopo-verify-result {
         display: none;
-        border-radius: 8px;
+        border-radius: 4px;
         padding: 1rem 1.5rem;
         margin-top: 1rem;
         font-size: 1.3rem;
@@ -656,7 +656,7 @@ noindex: true
     .setup-btn {
         padding: 10px 24px;
         border: none;
-        border-radius: 8px;
+        border-radius: 4px;
         font-size: 1.5rem;
         font-weight: 600;
         cursor: pointer;
@@ -791,7 +791,7 @@ noindex: true
         background: white;
         border: 1px solid #e9ecef;
         border-left: 4px solid #1e90ff;
-        border-radius: 8px;
+        border-radius: 4px;
         padding: 1.4rem 1.5rem;
         margin-bottom: 1rem;
         box-shadow: 0 1px 3px rgba(0, 0, 0, 0.04);
@@ -846,7 +846,7 @@ noindex: true
         font-size: 1.4rem;
         background: #fafbfc;
         border: 2px dashed #dee2e6;
-        border-radius: 12px;
+        border-radius: 6px;
     }
 
     @keyframes spin {
@@ -891,7 +891,7 @@ noindex: true
     .ct-handoff-box {
         background: #f0f7ff;
         border: 1px solid #c4ddf7;
-        border-radius: 8px;
+        border-radius: 4px;
         padding: 1rem 1.25rem;
         margin: 0.75rem 0 1rem;
         font-size: 1.4rem;
@@ -917,7 +917,7 @@ noindex: true
     }
     #qrScannerModal .qr-scanner-panel {
         background: #222;
-        border-radius: 12px;
+        border-radius: 6px;
         width: 100%;
         max-width: 400px;
         padding: 1rem;
@@ -931,7 +931,7 @@ noindex: true
     }
     #qrScannerModal #qrScannerReader {
         width: 100%;
-        border-radius: 8px;
+        border-radius: 4px;
         overflow: hidden;
         background: #000;
     }
@@ -984,7 +984,7 @@ noindex: true
     <div id="setupCodeEntry" style="display: none; text-align: center; padding: 2rem 0;">
         <h2 style="font-size: 2rem; font-weight: 600; color: #333; margin: 0 0 0.5rem;">Controller Setup</h2>
         <p style="font-size: 1.4rem; color: #888; margin: 0 0 2rem;">Enter your 6-digit activation code to get started.</p>
-        <input type="text" id="setupCodeInput" placeholder="ABC-123" maxlength="7" autocomplete="off" style="width: 100%; max-width: 280px; padding: 14px; font-size: 22px; font-weight: bold; text-align: center; border: 2px solid #dee2e6; border-radius: 8px; letter-spacing: 6px; text-transform: uppercase; font-family: 'Courier New', monospace; margin-bottom: 16px;">
+        <input type="text" id="setupCodeInput" placeholder="ABC-123" maxlength="7" autocomplete="off" style="width: 100%; max-width: 280px; padding: 14px; font-size: 22px; font-weight: bold; text-align: center; border: 2px solid #dee2e6; border-radius: 4px; letter-spacing: 6px; text-transform: uppercase; font-family: 'Courier New', monospace; margin-bottom: 16px;">
         <div>
             <button class="setup-btn setup-btn-primary" onclick="handleSetupCode()" id="setupCodeBtn" style="min-width: 200px;">Continue</button>
         </div>
@@ -1020,11 +1020,11 @@ noindex: true
     <div id="laptopHandoff" style="display: none; text-align: center;">
         <h2 class="form-step-question">Continue on your other device</h2>
         <p class="form-step-hint">On your laptop, desktop, or tablet, open a browser and go to:</p>
-        <div style="background: #f8f9fa; border-radius: 8px; padding: 12px; margin-bottom: 1.5rem;">
+        <div style="background: #f8f9fa; border-radius: 4px; padding: 12px; margin-bottom: 1.5rem;">
             <strong style="font-size: 1.6rem; color: #333;">EagleEyesSearch.com/setup</strong>
         </div>
         <p class="form-step-hint">Then enter this code:</p>
-        <div style="background: #f0f7ff; border: 2px solid #1e90ff; border-radius: 12px; padding: 16px; margin-bottom: 1.5rem;">
+        <div style="background: #f0f7ff; border: 2px solid #1e90ff; border-radius: 6px; padding: 16px; margin-bottom: 1.5rem;">
             <span id="handoffCode" style="font-size: 2.4rem; font-weight: bold; letter-spacing: 6px; font-family: 'Courier New', monospace; color: #333;"></span>
         </div>
         <p style="font-size: 1.3rem; color: #999;">You can close this page on your phone.</p>
@@ -1034,7 +1034,7 @@ noindex: true
     </div>
 
     <!-- Activation success banner (shown when redirected after activation) -->
-    <div id="activationSuccessBanner" style="display: none; background: #d4edda; border: 1px solid #c3e6cb; color: #155724; padding: 1rem 1.5rem; border-radius: 8px; margin-bottom: 1.5rem; text-align: center; font-size: 1.4rem;">
+    <div id="activationSuccessBanner" style="display: none; background: #d4edda; border: 1px solid #c3e6cb; color: #155724; padding: 1rem 1.5rem; border-radius: 4px; margin-bottom: 1.5rem; text-align: center; font-size: 1.4rem;">
         <span id="activationSuccessText"></span>
     </div>
 
@@ -1069,7 +1069,7 @@ noindex: true
 
     <!-- Intro screen (shown when arriving from activation) -->
     <div id="setupIntro" style="display: none;">
-        <div style="background: #f0f7ff; border: 1px solid #c4ddf7; border-radius: 12px; padding: 2rem; margin-bottom: 2rem;">
+        <div style="background: #f0f7ff; border: 1px solid #c4ddf7; border-radius: 6px; padding: 2rem; margin-bottom: 2rem;">
             <h2 id="introTitle" style="font-size: 1.8rem; font-weight: 600; color: #333; margin: 0 0 1rem;">Set up your controller</h2>
             <p id="introMessage" style="font-size: 1.4rem; color: #555; line-height: 1.6; margin: 0 0 1.5rem;">
                 Save your CalTopo credentials, default map, units, and procedures as a controller configuration.
@@ -1085,7 +1085,7 @@ noindex: true
 
     <!-- Save success screen (shown after saving from activation flow) -->
     <div id="saveSuccessScreen" style="display: none; text-align: center; padding: 2rem 0;">
-        <div style="background: #d4edda; border: 1px solid #c3e6cb; color: #155724; padding: 1.5rem; border-radius: 8px; margin-bottom: 1.5rem;">
+        <div style="background: #d4edda; border: 1px solid #c3e6cb; color: #155724; padding: 1.5rem; border-radius: 4px; margin-bottom: 1.5rem;">
             <h3 id="saveSuccessTitle" style="margin: 0 0 0.5rem; font-size: 1.6rem;">Controller Setup saved!</h3>
             <p id="saveSuccessMessage" style="margin: 0; font-size: 1.4rem;">Your Controller Setup has been synced. Verify on the controller via <strong>"Set Up Controller"</strong> in the menu.</p>
         </div>
@@ -1105,7 +1105,7 @@ noindex: true
 
     <!-- License ID dialog -->
     <div id="licenseDialog" style="display: none; position: fixed; top: 0; left: 0; width: 100%; height: 100%; background: rgba(0,0,0,0.5); z-index: 1002; justify-content: center; align-items: center;">
-        <div style="background: white; border-radius: 12px; padding: 2rem; width: 90%; max-width: 420px; box-shadow: 0 8px 30px rgba(0,0,0,0.15);">
+        <div style="background: white; border-radius: 6px; padding: 2rem; width: 90%; max-width: 420px; box-shadow: 0 8px 30px rgba(0,0,0,0.15);">
             <h3 style="font-size: 1.6rem; font-weight: 600; color: #333; margin: 0 0 0.5rem;">Enter License ID</h3>
             <p style="font-size: 1.3rem; color: #888; margin: 0 0 1.2rem;">Enter a license ID to find or create a Controller Setup.</p>
             <input type="text" id="setupLicenseInput" placeholder="e.g. ABC123" style="width: 100%; padding: 10px 12px; border: 1px solid #ddd; border-radius: 6px; font-size: 1.5rem; box-sizing: border-box; margin-bottom: 1rem;">
@@ -1243,8 +1243,8 @@ noindex: true
                         <div style="margin-bottom: 0.75rem;"><a href="{{ '/caltopo/' | relative_url }}" target="_blank" style="color: #1e90ff; text-decoration: none; font-weight: 700; font-size: 1.7rem;">EagleEyesSearch.com/caltopo</a></div>
                         <p style="font-size: 1.5rem; color: #333; margin: 0 0 1rem; line-height: 1.6;">After completing the form, copy the credentials code and paste it here:</p>
                         <div style="display: flex; gap: 0.5rem; margin-bottom: 0.5rem;">
-                            <input type="text" id="ctPasteField" readonly placeholder="Click Paste to fill" style="flex: 1; padding: 10px 12px; border: 1px solid #dee2e6; border-radius: 8px; font-size: 1.3rem; font-family: monospace; background: #fafbfc;">
-                            <button onclick="ctPasteFromClipboard()" style="white-space: nowrap; padding: 10px 16px; background: #e9ecef; color: #333; border: none; border-radius: 8px; font-size: 1.4rem; font-weight: 500; cursor: pointer; transition: all 0.2s;" onmousedown="this.style.background='#1e90ff'; this.style.color='white';" onmouseup="this.style.background='#e9ecef'; this.style.color='#333';" onmouseleave="this.style.background='#e9ecef'; this.style.color='#333';">Paste</button>
+                            <input type="text" id="ctPasteField" readonly placeholder="Click Paste to fill" style="flex: 1; padding: 10px 12px; border: 1px solid #dee2e6; border-radius: 4px; font-size: 1.3rem; font-family: monospace; background: #fafbfc;">
+                            <button onclick="ctPasteFromClipboard()" style="white-space: nowrap; padding: 10px 16px; background: #e9ecef; color: #333; border: none; border-radius: 4px; font-size: 1.4rem; font-weight: 500; cursor: pointer; transition: all 0.2s;" onmousedown="this.style.background='#1e90ff'; this.style.color='white';" onmouseup="this.style.background='#e9ecef'; this.style.color='#333';" onmouseleave="this.style.background='#e9ecef'; this.style.color='#333';">Paste</button>
                         </div>
                         <div>
                             <button class="setup-btn setup-btn-primary" onclick="handleCtPasteField()" style="width: 100%; max-width: 320px; margin-top: 0.5rem;">Verify</button>
@@ -1285,7 +1285,7 @@ noindex: true
                     <input type="text" id="ctServiceTitle" placeholder="e.g. Eagle Eyes">
                 </div>
                 <div style="text-align: center; margin: 0.75rem 0;">
-                    <img src="{{ '/images/caltopo-create-service-account.png' | relative_url }}" alt="CalTopo Create Service Account dialog" style="max-width: 100%; border-radius: 8px; border: 1px solid #ddd;">
+                    <img src="{{ '/images/caltopo-create-service-account.png' | relative_url }}" alt="CalTopo Create Service Account dialog" style="max-width: 100%; border-radius: 4px; border: 1px solid #ddd;">
                 </div>
                 <div class="form-step-actions">
                     <button class="setup-btn setup-btn-primary" onclick="validateCtTitle()">Done — I clicked Create</button>


### PR DESCRIPTION
## Summary
- /caltopo/: numbered steps, screenshot beside text, tighter spacing, admin access note, verify hint text, updated header copy
- /setup/: squared border-radius (8→4px, 12→6px) matching activation dialog style
- noindex meta tag on /caltopo/, /setup/, /activate/
- Removed duplicate divider above verify button

## Test plan
- [ ] /caltopo/ fits on one screen, verify button visible without scrolling
- [ ] Screenshot sits beside numbered list on wide screens, stacks on narrow
- [ ] /setup/ cards and inputs have squarer corners
- [ ] All three pages have noindex in page source

🤖 Generated with [Claude Code](https://claude.com/claude-code)