### PR TITLE
Revert "Remove Operator Day announcement banner"

### DIFF
--- a/_includes/announcement-banner.html
+++ b/_includes/announcement-banner.html
@@ -1,0 +1,25 @@
+<!-- Announcement Banner -->
+{% unless page.url == '/operatorday/' %}
+<div id="announcement-banner" style="
+    background: #1a1a2e;
+    color: #fff;
+    text-align: center;
+    padding: 10px 20px;
+    font-family: 'Inter', sans-serif;
+    font-size: 15px;
+    line-height: 1.4;
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    z-index: 1001;
+">
+    <span style="display: block; text-align: center;">Come train and fly with us at <a href="/operatorday/" style="color: #5cb8ff; font-weight: 600; text-decoration: underline;">Eagle Eyes Operator Day</a> - April 24 &amp; 25, Las Vegas</span>
+</div>
+<style>
+    /* Push content and navbar below the fixed banner */
+    body { padding-top: 41px; }
+    .header-absolute { top: 41px !important; }
+    .header-sticky .header-inner { top: 41px !important; }
+</style>
+{% endunless %}

--- a/_layouts/main.html
+++ b/_layouts/main.html
@@ -5,6 +5,8 @@
 
   <body class="shop home-page">
 
+    {% include announcement-banner.html %}
+
     {% include navbar-main.html %}
 
     {{ content }}


### PR DESCRIPTION
## Summary
- Reverts #279 — restores the Operator Day announcement banner and the `_includes/announcement-banner.html` partial

## Test plan
- [ ] Verify banner appears again at top of pages using the `main` layout
- [ ] Confirm banner is hidden on `/operatorday/` page