### PR TITLE
Reframe CalTopo desktop fallback as "Can't scan a QR code?"

### DIFF
--- a/setup.html
+++ b/setup.html
@@ -1227,19 +1227,20 @@ noindex: true
                             <button class="setup-btn setup-btn-primary" onclick="openCaltopoQrScanner()" style="width: 100%; max-width: 320px;">Scan QR Code</button>
                         </div>
 
-                        <div style="margin-top: 0.75rem;">
-                            <a href="#" id="ctDesktopPasteToggle" onclick="ctShowDesktopPaste(); return false;" style="color: #888; font-size: 1.3rem; text-decoration: underline;">Viewing this on desktop? Paste your CalTopo code here &rarr;</a>
-                        </div>
+                        <div style="margin-top: 1.25rem; padding-top: 1rem; border-top: 1px solid #dee2e6;">
+                            <a href="#" id="ctDesktopPasteToggle" onclick="ctShowDesktopPaste(); return false;" style="color: #888; font-size: 1.3rem; text-decoration: underline;">Can't scan a QR code?</a>
 
-                        <div id="ctDesktopPaste" style="display: none; margin-top: 0.75rem;">
-                            <div style="display: flex; gap: 0.5rem; margin-bottom: 0.5rem;">
-                                <input type="text" id="ctPasteField" readonly placeholder="Click Paste to fill" style="flex: 1; padding: 10px 12px; border: 1px solid #dee2e6; border-radius: 4px; font-size: 1.3rem; font-family: monospace; background: #fafbfc;">
-                                <button onclick="ctPasteFromClipboard()" style="white-space: nowrap; padding: 10px 16px; background: #e9ecef; color: #333; border: none; border-radius: 4px; font-size: 1.4rem; font-weight: 500; cursor: pointer; transition: all 0.2s;" onmousedown="this.style.background='#1e90ff'; this.style.color='white';" onmouseup="this.style.background='#e9ecef'; this.style.color='#333';" onmouseleave="this.style.background='#e9ecef'; this.style.color='#333';">Paste</button>
+                            <div id="ctDesktopPaste" style="display: none; margin-top: 0.75rem;">
+                                <p style="font-size: 1.4rem; color: #333; margin: 0 0 0.75rem; line-height: 1.6;">Completing the form on <a href="{{ '/caltopo/' | relative_url }}" target="_blank" style="color: #1e90ff; text-decoration: none; font-weight: 600;">eagleeyessearch.com/caltopo</a> also generates a code. Click the <strong>Copy code</strong> button there, then paste it below.</p>
+                                <div style="display: flex; gap: 0.5rem; margin-bottom: 0.5rem;">
+                                    <input type="text" id="ctPasteField" readonly placeholder="Click Paste to fill" style="flex: 1; padding: 10px 12px; border: 1px solid #dee2e6; border-radius: 4px; font-size: 1.3rem; font-family: monospace; background: #fafbfc;">
+                                    <button onclick="ctPasteFromClipboard()" style="white-space: nowrap; padding: 10px 16px; background: #e9ecef; color: #333; border: none; border-radius: 4px; font-size: 1.4rem; font-weight: 500; cursor: pointer; transition: all 0.2s;" onmousedown="this.style.background='#1e90ff'; this.style.color='white';" onmouseup="this.style.background='#e9ecef'; this.style.color='#333';" onmouseleave="this.style.background='#e9ecef'; this.style.color='#333';">Paste</button>
+                                </div>
+                                <div>
+                                    <button class="setup-btn setup-btn-primary" onclick="handleCtPasteField()" style="width: 100%; max-width: 320px; margin-top: 0.5rem;">Verify</button>
+                                </div>
+                                <div id="ctPasteError" style="display: none; font-size: 1.3rem; color: #d93025; margin-top: 0.5rem;"></div>
                             </div>
-                            <div>
-                                <button class="setup-btn setup-btn-primary" onclick="handleCtPasteField()" style="width: 100%; max-width: 320px; margin-top: 0.5rem;">Verify</button>
-                            </div>
-                            <div id="ctPasteError" style="display: none; font-size: 1.3rem; color: #d93025; margin-top: 0.5rem;"></div>
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
## Summary
- Renamed the desktop/paste fallback link from "Viewing this on desktop? Paste your CalTopo code here" to **"Can't scan a QR code?"** — better captures the actual fallback case (anyone who can't get the scan to work, not just desktop users)
- Visually separated the fallback from the Scan QR Code button with a divider and extra top margin so it reads as an alternative path, not an appendage
- Fold-out now leads with a short explanation that names the **Copy code** button on `/caltopo/`, matching the wording on that page so users know exactly what to look for

## Test plan
- [ ] On `/setup/`, open the CalTopo card and choose to create a new service account — confirm the mobile/QR flow shows by default
- [ ] Confirm the "Can't scan a QR code?" link appears in a visually distinct section below the Scan QR Code button
- [ ] Click the link — confirm the explanatory text and paste field fold out
- [ ] Complete the form on `/caltopo/`, click **Copy code**, paste into setup, click **Verify** — end-to-end flow still works