### PR TITLE
Unify Controller Setup list views + Select button + Back nav fix

### DIFF
--- a/setup.html
+++ b/setup.html
@@ -2014,7 +2014,9 @@ function showIntroScreen(configs) {
             html += renderConfigDetails(cfg, 'intro' + index, true);
             html += '</div>';
             html += '</div>';
-            html += '<div style="color: #adb5bd; font-size: 2rem; flex-shrink: 0;">&#8250;</div>';
+            html += '<div style="flex-shrink: 0;">';
+            html += '<button class="setup-btn setup-btn-primary" onclick="event.stopPropagation(); introSelectConfig(' + index + ');" style="padding: 8px 18px; font-size: 1.4rem;">Select</button>';
+            html += '</div>';
             html += '</div>';
         });
         existingEl.innerHTML = html;

--- a/setup.html
+++ b/setup.html
@@ -1002,7 +1002,7 @@ noindex: true
 
     <!-- Page header -->
     <div class="setup-header" id="setupHeader" style="display: none;">
-        <h1>Controller Setup</h1>
+        <h1>Saved Settings</h1>
     </div>
 
     <!-- Mobile recommendation screen (shown before wizard step 1 on mobile) -->
@@ -1069,7 +1069,6 @@ noindex: true
     <!-- Intro screen (shown when arriving from activation) -->
     <div id="setupIntro" style="display: none;">
         <div style="background: #f0f7ff; border: 1px solid #c4ddf7; border-radius: 6px; padding: 2rem; margin-bottom: 2rem;">
-            <h2 style="font-size: 1.8rem; font-weight: 600; color: #333; margin: 0 0 1rem;">Controller Setup</h2>
             <p style="font-size: 1.4rem; color: #555; line-height: 1.6; margin: 0 0 1.5rem;">
                 Store and share your setup — like CalTopo map connections, coordinate systems, and procedures — across your devices and teams.
             </p>
@@ -1093,7 +1092,6 @@ noindex: true
     <!-- Controller Setup list (shown after auth) -->
     <div id="setupConfigList" style="display: none;">
         <div style="background: #f0f7ff; border: 1px solid #c4ddf7; border-radius: 6px; padding: 2rem; margin-bottom: 2rem;">
-            <h2 style="font-size: 1.8rem; font-weight: 600; color: #333; margin: 0 0 1rem;">Controller Setup</h2>
             <p style="font-size: 1.4rem; color: #555; line-height: 1.6; margin: 0 0 1.5rem;">
                 Store and share your setup — like CalTopo map connections, coordinate systems, and procedures — across your devices and teams.
             </p>

--- a/setup.html
+++ b/setup.html
@@ -1069,10 +1069,9 @@ noindex: true
     <!-- Intro screen (shown when arriving from activation) -->
     <div id="setupIntro" style="display: none;">
         <div style="background: #f0f7ff; border: 1px solid #c4ddf7; border-radius: 6px; padding: 2rem; margin-bottom: 2rem;">
-            <h2 id="introTitle" style="font-size: 1.8rem; font-weight: 600; color: #333; margin: 0 0 1rem;">Set up your controller</h2>
-            <p id="introMessage" style="font-size: 1.4rem; color: #555; line-height: 1.6; margin: 0 0 1.5rem;">
-                Save your CalTopo credentials, default map, units, and procedures as a controller configuration.
-                When new team members activate a device on this license, their controller will be set up automatically.
+            <h2 style="font-size: 1.8rem; font-weight: 600; color: #333; margin: 0 0 1rem;">Controller Setup</h2>
+            <p style="font-size: 1.4rem; color: #555; line-height: 1.6; margin: 0 0 1.5rem;">
+                Store and share your setup — like CalTopo map connections, coordinate systems, and procedures — across your devices and teams.
             </p>
             <div id="introExistingConfigs"></div>
             <div style="display: flex; gap: 1rem; flex-wrap: wrap; margin-top: 1.5rem;">
@@ -1094,11 +1093,14 @@ noindex: true
     <!-- Controller Setup list (shown after auth) -->
     <div id="setupConfigList" style="display: none;">
         <div style="background: #f0f7ff; border: 1px solid #c4ddf7; border-radius: 6px; padding: 2rem; margin-bottom: 2rem;">
-            <p style="font-size: 1.4rem; color: #555; line-height: 1.6; margin: 0 0 1.25rem;">Store and share Controller Setups across your team.</p>
+            <h2 style="font-size: 1.8rem; font-weight: 600; color: #333; margin: 0 0 1rem;">Controller Setup</h2>
+            <p style="font-size: 1.4rem; color: #555; line-height: 1.6; margin: 0 0 1.5rem;">
+                Store and share your setup — like CalTopo map connections, coordinate systems, and procedures — across your devices and teams.
+            </p>
             <div style="font-size: 12px; color: #999; margin-bottom: 1rem;" id="configListSubtitle"></div>
             <div style="font-size: 12px; color: #999; margin-bottom: 1rem;" id="setupLicenseLink"><strong>License ID required.</strong> <a href="#" onclick="showLicenseDialog(); return false;" style="color: #1e90ff;">Enter license ID</a></div>
             <div id="configListItems"></div>
-            <div style="margin-top: 1rem;">
+            <div style="margin-top: 1.5rem;">
                 <button class="setup-btn" onclick="createNewConfiguration()" style="background-color: #28a745; color: white; box-shadow: 0 2px 8px rgba(40,167,69,0.25);">+ New</button>
             </div>
             <div class="setup-status" id="configListStatus"></div>
@@ -1985,37 +1987,26 @@ function showIntroScreen(configs) {
     document.getElementById('setupConfigList').style.display = 'none';
     document.getElementById('setupForm').style.display = 'none';
     document.getElementById('setupHeader').style.display = 'none';
-    var introEl = document.getElementById('setupIntro');
-    introEl.style.display = '';
+    document.getElementById('setupIntro').style.display = '';
 
-    var titleEl = document.getElementById('introTitle');
-    var messageEl = document.getElementById('introMessage');
     var existingEl = document.getElementById('introExistingConfigs');
     var setupBtn = document.getElementById('introSetupBtn');
     var skipBtn = document.getElementById('introSkipBtn');
 
     if (configs === null) {
-        // Loading state — neutral, no title that assumes no configs
-        titleEl.textContent = '';
-        messageEl.textContent = '';
         existingEl.innerHTML = '<div style="text-align: center; padding: 2rem; color: #888;"><div class="spinner" style="margin: 0 auto 0.75rem;"></div>Loading...</div>';
         setupBtn.style.display = 'none';
         skipBtn.style.display = 'none';
     } else if (configs && configs.length > 0) {
-        titleEl.textContent = 'Controller Setup available';
-        messageEl.textContent = 'Select a Controller Setup from the list below, or create a new one.';
         setupBtn.textContent = 'Create New';
         setupBtn.style.display = '';
         skipBtn.style.display = '';
-
         var html = '';
         configs.forEach(function(config, index) {
             html += renderConfigCard(config, index, 'activation');
         });
         existingEl.innerHTML = html;
     } else {
-        titleEl.textContent = 'Set up your controller';
-        messageEl.textContent = 'Save your CalTopo credentials, default map, units, and procedures as a Controller Setup. When new team members activate a device on this license, their controller will be set up automatically.';
         setupBtn.textContent = 'Create New Settings';
         setupBtn.style.display = '';
         skipBtn.style.display = '';

--- a/setup.html
+++ b/setup.html
@@ -1003,7 +1003,6 @@ noindex: true
     <!-- Page header -->
     <div class="setup-header" id="setupHeader" style="display: none;">
         <h1>Controller Setup</h1>
-        <p>Store and share your Controller Setup — like CalTopo map connections, coordinate systems, and procedures — across your team.</p>
     </div>
 
     <!-- Mobile recommendation screen (shown before wizard step 1 on mobile) -->
@@ -1094,13 +1093,16 @@ noindex: true
 
     <!-- Controller Setup list (shown after auth) -->
     <div id="setupConfigList" style="display: none;">
-        <div style="font-size: 12px; color: #999; margin-bottom: 1rem;" id="configListSubtitle"></div>
-        <div style="font-size: 12px; color: #999; margin-bottom: 1rem;" id="setupLicenseLink"><strong>License ID required.</strong> <a href="#" onclick="showLicenseDialog(); return false;" style="color: #1e90ff;">Enter license ID</a></div>
-        <div style="margin-bottom: 1rem;">
-            <button class="setup-btn" onclick="createNewConfiguration()" style="background-color: #28a745; color: white; box-shadow: 0 2px 8px rgba(40,167,69,0.25);">+ New</button>
+        <div style="background: #f0f7ff; border: 1px solid #c4ddf7; border-radius: 6px; padding: 2rem; margin-bottom: 2rem;">
+            <p style="font-size: 1.4rem; color: #555; line-height: 1.6; margin: 0 0 1.25rem;">Store and share Controller Setups across your team.</p>
+            <div style="font-size: 12px; color: #999; margin-bottom: 1rem;" id="configListSubtitle"></div>
+            <div style="font-size: 12px; color: #999; margin-bottom: 1rem;" id="setupLicenseLink"><strong>License ID required.</strong> <a href="#" onclick="showLicenseDialog(); return false;" style="color: #1e90ff;">Enter license ID</a></div>
+            <div id="configListItems"></div>
+            <div style="margin-top: 1rem;">
+                <button class="setup-btn" onclick="createNewConfiguration()" style="background-color: #28a745; color: white; box-shadow: 0 2px 8px rgba(40,167,69,0.25);">+ New</button>
+            </div>
+            <div class="setup-status" id="configListStatus"></div>
         </div>
-        <div id="configListItems"></div>
-        <div class="setup-status" id="configListStatus"></div>
     </div>
 
     <!-- License ID dialog -->
@@ -1422,6 +1424,7 @@ var currentConfigurationId = null;
 var currentLicenseId = null;
 var caltopoVerifiedData = null; // Stores fetched CalTopo metadata after verification
 var cachedConfigurations = []; // Cached list of user configurations
+var cameFromActivationIntro = false; // True when user reached the form via the activation intro screen
 
 // URL parameters from app
 var urlSetupParams = new URLSearchParams(window.location.search);
@@ -1978,6 +1981,7 @@ document.getElementById('ctMapDropdown').addEventListener('change', function() {
 // --- Intro screen (shown when arriving from activation) ---
 
 function showIntroScreen(configs) {
+    cameFromActivationIntro = true;
     document.getElementById('setupConfigList').style.display = 'none';
     document.getElementById('setupForm').style.display = 'none';
     document.getElementById('setupHeader').style.display = 'none';
@@ -2006,18 +2010,7 @@ function showIntroScreen(configs) {
 
         var html = '';
         configs.forEach(function(config, index) {
-            var cfg = config.config || {};
-            html += '<div class="config-card" onclick="introSelectConfig(' + index + ')" style="cursor: pointer; display: flex; align-items: center; gap: 1rem;">';
-            html += '<div style="flex: 1;">';
-            html += '<h3>' + escapeHtml(config.label || 'Unnamed') + '</h3>';
-            html += '<div style="font-size: 1.3rem; color: #666; line-height: 1.8;">';
-            html += renderConfigDetails(cfg, 'intro' + index, true);
-            html += '</div>';
-            html += '</div>';
-            html += '<div style="flex-shrink: 0;">';
-            html += '<button class="setup-btn setup-btn-primary" onclick="event.stopPropagation(); introSelectConfig(' + index + ');" style="padding: 8px 18px; font-size: 1.4rem;">Select</button>';
-            html += '</div>';
-            html += '</div>';
+            html += renderConfigCard(config, index, 'activation');
         });
         existingEl.innerHTML = html;
     } else {
@@ -2129,6 +2122,7 @@ async function loadConfigurationsForIntro() {
 }
 
 async function loadConfigurations() {
+    cameFromActivationIntro = false;
     var licenseInput = document.getElementById('setupLicenseInput').value.trim();
     currentLicenseId = licenseInput || null;
     clearStatus('setupLicenseStatus');
@@ -2174,6 +2168,28 @@ async function loadConfigurations() {
     }
 }
 
+function renderConfigCard(config, index, mode) {
+    var cfg = config.config || {};
+    var html = '<div class="config-card" style="position: relative;">';
+    html += '<a href="#" onclick="event.stopPropagation(); deleteConfigurationByIndex(' + index + '); return false;" class="config-card-delete" title="Delete">';
+    html += '<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="3 6 5 6 21 6"></polyline><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"></path></svg>';
+    html += '</a>';
+    html += '<h3>' + escapeHtml(config.label || 'Unnamed') + '</h3>';
+    html += '<div style="font-size: 1.5rem; color: #555; line-height: 2;">';
+    html += renderConfigDetails(cfg, mode + index, false);
+    html += '</div>';
+    html += '<div style="margin-top: 0.75rem; display: flex; gap: 0.75rem; justify-content: center; flex-wrap: wrap;">';
+    if (mode === 'activation') {
+        html += '<button class="setup-btn setup-btn-secondary" onclick="editConfiguration(' + index + ')"><span style="margin-right: 6px;">&#9998;</span> Edit</button>';
+        html += '<button class="setup-btn setup-btn-primary" onclick="introSelectConfig(' + index + ')">Select</button>';
+    } else {
+        html += '<button class="setup-btn setup-btn-primary" onclick="editConfiguration(' + index + ')"><span style="margin-right: 6px;">&#9998;</span> Edit</button>';
+    }
+    html += '</div>';
+    html += '</div>';
+    return html;
+}
+
 function renderConfigList(configs) {
     var listEl = document.getElementById('configListItems');
     if (!configs || configs.length === 0) {
@@ -2182,20 +2198,7 @@ function renderConfigList(configs) {
     }
     var html = '';
     configs.forEach(function(config, index) {
-        var cfg = config.config || {};
-
-        html += '<div class="config-card" style="position: relative;">';
-        html += '<a href="#" onclick="deleteConfigurationByIndex(' + index + '); return false;" class="config-card-delete" title="Delete">';
-        html += '<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="3 6 5 6 21 6"></polyline><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"></path></svg>';
-        html += '</a>';
-        html += '<h3>' + escapeHtml(config.label || 'Unnamed') + '</h3>';
-        html += '<div style="font-size: 1.5rem; color: #555; line-height: 2;">';
-        html += renderConfigDetails(cfg, 'config' + index);
-        html += '</div>';
-        html += '<div style="text-align: center; margin-top: 0.75rem;">';
-        html += '<button class="setup-btn setup-btn-primary" onclick="editConfiguration(' + index + ')"><span style="margin-right: 6px;">&#9998;</span> Edit</button>';
-        html += '</div>';
-        html += '</div>';
+        html += renderConfigCard(config, index, 'manage');
     });
     listEl.innerHTML = html;
 }
@@ -2383,7 +2386,11 @@ function showConfigList() {
     document.getElementById('procToggleWrap').style.display = 'none';
     document.getElementById('wizardStepper').style.display = 'none';
     clearStatus('setupFormStatus');
-    loadConfigurations();
+    if (cameFromActivationIntro) {
+        loadConfigurationsForIntro();
+    } else {
+        loadConfigurations();
+    }
     window.scrollTo(0, 0);
 }
 


### PR DESCRIPTION
## Summary
The setup page had two separate renderings of Controller Setups that confused users: an activation intro (Select only) and a management overview (Edit/Delete only). Hitting **Back** from Create New during activation dropped the user into the management view — a different layout with different controls. This PR unifies both views and adds a clearer selection affordance.

### Changes
- **`renderConfigCard(config, index, mode)`** — single shared card renderer used by both `showIntroScreen` (activation mode) and `renderConfigList` (manage mode). Cards always have Delete (top-right) + Edit. Activation mode also shows a Select button.
- **Explicit Select button** in activation mode (no more relying on whole-card click), so users unambiguously know where to tap.
- **Cards are no longer single click targets.** All actions go through explicit buttons, so inner URLs/procedure text can linkify without stealing selection clicks.
- **Back navigation fix**: `cameFromActivationIntro` flag tracks which view the user came from; `showConfigList` routes Back to either intro or management accordingly.
- **Layout unification**: `#setupConfigList` now wraps its content in the same blue panel used by the intro, and the redundant setup-header paragraph was removed. "+ New" moved from top to bottom of the management list to match the intro's "buttons below list" pattern.

## Test plan
- [ ] Activation flow (land with session_id) → confirm unified cards show Edit + Select and a trash icon
- [ ] Click **Select** → activation completes as before
- [ ] Click **Edit** → form opens; click **Back** → returns to intro view (not management)
- [ ] Click **Delete** (trash) from intro → removes and re-renders the intro list
- [ ] Direct access → confirm cards show Edit + Delete (no Select); "+ New" appears below the list
- [ ] Click **Edit** in management → form → **Back** → returns to management (not intro)
- [ ] Mobile: action buttons wrap cleanly; trash stays top-right