### PR TITLE
Neutralize "controller" in user-facing setup copy

### DIFF
--- a/setup.html
+++ b/setup.html
@@ -1,6 +1,6 @@
 ---
 layout: main
-title: Controller Setup - Eagle Eyes
+title: Saved Settings - Eagle Eyes
 permalink: /setup/
 noindex: true
 ---
@@ -1150,7 +1150,7 @@ noindex: true
 
     <!-- Code entry landing (shown when accessing /setup/ directly without params) -->
     <div id="setupCodeEntry" style="display: none; text-align: center; padding: 2rem 0;">
-        <h2 style="font-size: 2rem; font-weight: 600; color: #333; margin: 0 0 0.5rem;">Controller Setup</h2>
+        <h2 style="font-size: 2rem; font-weight: 600; color: #333; margin: 0 0 0.5rem;">Setup</h2>
         <p style="font-size: 1.4rem; color: #888; margin: 0 0 2rem;">Enter your 6-digit activation code to get started.</p>
         <input type="text" id="setupCodeInput" placeholder="ABC-123" maxlength="7" autocomplete="off" style="width: 100%; max-width: 280px; padding: 14px; font-size: 22px; font-weight: bold; text-align: center; border: 2px solid #dee2e6; border-radius: 4px; letter-spacing: 6px; text-transform: uppercase; font-family: 'Courier New', monospace; margin-bottom: 16px;">
         <div>
@@ -1164,7 +1164,7 @@ noindex: true
 
     <!-- Sign-in prompt (shown when not authenticated) -->
     <div id="setupSigninSection" class="setup-signin-section" style="display: none;">
-        <p style="margin-bottom: 20px;">Sign in to manage your Controller Setup.</p>
+        <p style="margin-bottom: 20px;">Sign in to manage your saved settings.</p>
         <button class="setup-signin-btn" onclick="toggleSignIn()">Sign In or Create Account</button>
     </div>
 
@@ -1176,7 +1176,7 @@ noindex: true
     <!-- Mobile recommendation screen (shown before wizard step 1 on mobile) -->
     <div id="mobileRecommendation" style="display: none;">
         <h2 class="form-step-question">Setting up on a small screen?</h2>
-        <p class="form-step-hint">You'll need a laptop, desktop, or tablet to create a new Controller Setup.</p>
+        <p class="form-step-hint">You'll need a laptop, desktop, or tablet to create a new setup.</p>
         <div class="form-step-actions">
             <button class="setup-btn setup-btn-primary" onclick="showLaptopHandoff()">I have a laptop/desktop/tablet ready</button>
             <a href="#" class="back-link" onclick="showConfigList(); return false;">Back</a>
@@ -1245,7 +1245,7 @@ noindex: true
                 This step is optional — you can also configure later.
             </p>
             <div style="display: flex; gap: 1rem; flex-wrap: wrap; margin-top: 0.25rem;">
-                <button class="setup-btn setup-btn-primary" id="introSetupBtn" onclick="introSetupController()">Set Up Controller</button>
+                <button class="setup-btn setup-btn-primary" id="introSetupBtn" onclick="introSetupController()">Create New</button>
                 <button class="setup-btn setup-btn-secondary" id="introSkipBtn" onclick="introSkip()">Skip setup</button>
             </div>
             <div id="introStatus" style="display: none; margin-top: 1rem; padding: 0.75rem 1rem; border-radius: 4px; font-size: 1.3rem;"></div>
@@ -1255,10 +1255,10 @@ noindex: true
     <!-- Save success screen (shown after saving from activation flow) -->
     <div id="saveSuccessScreen" style="display: none; text-align: center; padding: 2rem 0;">
         <div style="background: #d4edda; border: 1px solid #c3e6cb; color: #155724; padding: 1.5rem; border-radius: 4px; margin-bottom: 1.5rem;">
-            <h3 id="saveSuccessTitle" style="margin: 0 0 0.5rem; font-size: 1.6rem;">Controller Setup saved!</h3>
-            <p id="saveSuccessMessage" style="margin: 0; font-size: 1.4rem;">Your Controller Setup has been synced. Verify on the controller via <strong>"Set Up Controller"</strong> in the menu.</p>
+            <h3 id="saveSuccessTitle" style="margin: 0 0 0.5rem; font-size: 1.6rem;">Settings saved!</h3>
+            <p id="saveSuccessMessage" style="margin: 0; font-size: 1.4rem;">Your settings have been synced. You can close this window.</p>
         </div>
-        <a href="#" onclick="showConfigListFromSuccess(); return false;" style="font-size: 1.4rem; color: #1e90ff; text-decoration: none;">See all Controller Setups &rarr;</a>
+        <a href="#" onclick="showConfigListFromSuccess(); return false;" style="font-size: 1.4rem; color: #1e90ff; text-decoration: none;">See all saved settings &rarr;</a>
     </div>
 
     <!-- Controller Setup list (shown after auth) -->
@@ -1281,7 +1281,7 @@ noindex: true
     <div id="licenseDialog" style="display: none; position: fixed; top: 0; left: 0; width: 100%; height: 100%; background: rgba(0,0,0,0.5); z-index: 1002; justify-content: center; align-items: center;">
         <div style="background: white; border-radius: 6px; padding: 2rem; width: 90%; max-width: 420px; box-shadow: 0 8px 30px rgba(0,0,0,0.15);">
             <h3 style="font-size: 1.6rem; font-weight: 600; color: #333; margin: 0 0 0.5rem;">Enter License ID</h3>
-            <p style="font-size: 1.3rem; color: #888; margin: 0 0 1.2rem;">Enter a license ID to find or create a Controller Setup.</p>
+            <p style="font-size: 1.3rem; color: #888; margin: 0 0 1.2rem;">Enter a license ID to find or create a setup.</p>
             <input type="text" id="setupLicenseInput" placeholder="e.g. ABC123" style="width: 100%; padding: 10px 12px; border: 1px solid #ddd; border-radius: 6px; font-size: 1.5rem; box-sizing: border-box; margin-bottom: 1rem;">
             <div class="setup-status" id="setupLicenseStatus"></div>
             <div style="display: flex; gap: 0.75rem; justify-content: flex-end; margin-top: 1rem;">
@@ -1400,7 +1400,7 @@ noindex: true
 
                 <!-- Folds out inside the same container when checked: no account yet -->
                 <div id="ctNoAccount" style="display: none; margin-top: 1rem; padding-top: 0.75rem; border-top: 1px solid #dee2e6;" onclick="event.stopPropagation();">
-                    <p style="font-size: 1.5rem; color: #333; margin: 0 0 1rem; line-height: 1.6;">A CalTopo service account keeps your controller permanently connected to CalTopo, so you don't have to log in manually every few days.</p>
+                    <p style="font-size: 1.5rem; color: #333; margin: 0 0 1rem; line-height: 1.6;">A CalTopo service account stays signed in for you, so you don't have to log in manually every few days.</p>
 
                     <div>
                         <p style="font-size: 1.5rem; color: #333; margin: 0 0 0.75rem; line-height: 1.6;">Keep this page open and open a browser on your desktop or laptop. Go to:</p>
@@ -1532,7 +1532,7 @@ noindex: true
             <div class="toggle-status">&#10003;</div>
             <div style="flex: 1;">
                 <div class="toggle-label">Procedures &amp; Emergency Contacts</div>
-                <div class="toggle-desc">Quick-access procedures and contacts on your controller</div>
+                <div class="toggle-desc">Quick-access procedures and contacts in the field</div>
 
                 <div id="procContent" style="display: none; margin-top: 1rem; padding-top: 0.75rem; border-top: 1px solid #dee2e6;" onclick="event.stopPropagation();">
                     <div class="setup-field">
@@ -1541,7 +1541,7 @@ noindex: true
                     </div>
                     <div class="setup-field">
                         <label for="setupProceduresLink">Link to Full Document</label>
-                        <p style="font-size: 1.3rem; color: #888; margin-bottom: 0.5rem;">This URL will be converted into a QR code on the controller.</p>
+                        <p style="font-size: 1.3rem; color: #888; margin-bottom: 0.5rem;">This URL will be converted into a QR code in the app.</p>
                         <input type="url" id="setupProceduresLink" placeholder="https://docs.google.com/..." oninput="updateToggleState('procedures')">
                     </div>
                 </div>
@@ -2318,8 +2318,8 @@ async function introSkip() {
         document.getElementById('activationSuccessBanner').style.display = 'none';
         document.getElementById('saveSuccessTitle').textContent = hadActivation ? 'Skipped!' : 'Setup complete!';
         document.getElementById('saveSuccessMessage').innerHTML = hadActivation
-            ? 'Your controller will continue with its existing settings. You can close this window or continue to manage your Controller Setup.'
-            : 'You can close this window or continue to manage your Controller Setup.';
+            ? 'Your existing settings will be kept. You can close this window or continue to manage your saved settings.'
+            : 'You can close this window or continue to manage your saved settings.';
         document.getElementById('saveSuccessScreen').style.display = 'block';
         window.scrollTo(0, 0);
     };
@@ -2415,7 +2415,7 @@ async function loadConfigurations() {
 
     var listEl = document.getElementById('configListItems');
     var statusEl = document.getElementById('configListStatus');
-    listEl.innerHTML = '<div style="text-align: center; padding: 2rem; color: #888;"><div class="spinner" style="margin: 0 auto 1rem;"></div>Loading Controller Setups...</div>';
+    listEl.innerHTML = '<div style="text-align: center; padding: 2rem; color: #888;"><div class="spinner" style="margin: 0 auto 1rem;"></div>Loading saved settings...</div>';
     statusEl.className = 'setup-status';
     statusEl.textContent = '';
 
@@ -2429,7 +2429,7 @@ async function loadConfigurations() {
     } catch (err) {
         console.error('Error loading Controller Setups:', err);
         listEl.innerHTML = '';
-        statusEl.textContent = 'Error loading Controller Setups: ' + err.message;
+        statusEl.textContent = 'Error loading saved settings: ' + err.message;
         statusEl.className = 'setup-status error';
     }
 }
@@ -2499,7 +2499,7 @@ function toggleConfigSection(uniqueId) {
 function renderConfigList(configs) {
     var listEl = document.getElementById('configListItems');
     if (!configs || configs.length === 0) {
-        listEl.innerHTML = '<div class="config-card-empty">No Controller Setups found. Click "+ New" to create one.</div>';
+        listEl.innerHTML = '<div class="config-card-empty">No saved settings found. Click "+ New" to create one.</div>';
         return;
     }
     var html = '';
@@ -2621,7 +2621,7 @@ function submitLicenseDialog() {
 }
 
 function getDefaultName() {
-    var baseName = 'Controller Setup';
+    var baseName = 'Setup';
     var existingNames = (cachedConfigurations || []).map(function(c) { return c.label || ''; });
     for (var i = 1; i <= 20; i++) {
         var candidate = baseName + ' ' + i;
@@ -2749,7 +2749,7 @@ function showSingleStepSuccess() {
     document.getElementById('setupForm').style.display = 'none';
     var what = caltopoOnly ? 'CalTopo' : 'Procedures';
     document.getElementById('saveSuccessTitle').textContent = what + ' setup complete!';
-    document.getElementById('saveSuccessMessage').innerHTML = 'Your Controller Setup has been saved and will sync to the controller within 10 seconds. You can close this window.';
+    document.getElementById('saveSuccessMessage').innerHTML = 'Your settings have been saved and will sync within 10 seconds. You can close this window.';
     document.getElementById('saveSuccessScreen').style.display = 'block';
 }
 
@@ -2952,7 +2952,7 @@ function nextStep() {
     if (currentFormStep === 1) {
         var name = document.getElementById('setupName').value.trim();
         if (!name) {
-            showStatus('setupFormStatus', 'Please enter a name for this Controller Setup.', 'error');
+            showStatus('setupFormStatus', 'Please enter a name for this setup.', 'error');
             return;
         }
         // Check for duplicate name (exclude current config being edited)
@@ -2960,7 +2960,7 @@ function nextStep() {
             return (c.label || '') === name && c.configuration_id !== currentConfigurationId;
         });
         if (duplicate) {
-            showStatus('setupFormStatus', 'A Controller Setup with this name already exists. Please choose a different name.', 'error');
+            showStatus('setupFormStatus', 'A setup with this name already exists. Please choose a different name.', 'error');
             return;
         }
         clearStatus('setupFormStatus');
@@ -4120,7 +4120,7 @@ async function deleteConfigurationByIndex(index) {
                 // Show activation success banner if redirected after activation
                 if (activationSuccess) {
                     var banner = document.getElementById('activationSuccessBanner');
-                    document.getElementById('activationSuccessText').textContent = 'License activation completed! Your license will sync to the controller — this may take up to 10 seconds. Next step: select or create a controller configuration below.';
+                    document.getElementById('activationSuccessText').textContent = 'License activation completed! Your license will sync within 10 seconds. Next step: select or create a setup below.';
                     banner.style.display = 'block';
                     // Clear activation_success from URL to prevent stale banner on revisit
                     if (window.history && window.history.replaceState) {


### PR DESCRIPTION
Flow will be reused beyond Eagle Eyes Pilot (e.g. Mirada), so avoid product-specific device language in the UI. Per guidance: drop "controller" everywhere visible; fall back to "Eagle Eyes" only if a subject is truly required.

User-visible changes:
- Skip success copy: "Your controller will continue with its existing settings..." → "Your existing settings will be kept..." and drop "Controller Setup" in favor of "saved settings".
- Page title, code-entry heading, sign-in prompt, mobile hint, license dialog, loading / empty / error states, save success, form validation, activation success banner: rephrase to "setup" / "saved settings" or drop the noun entirely where possible.
- CalTopo service-account blurb rephrased to "stays signed in for you" so no device noun is needed.
- Procedures toggle-desc now reads "Quick-access procedures and contacts in the field".
- QR-code hint now reads "…converted into a QR code in the app."
- Intro "Set Up Controller" button defaults to "Create New" to match what the JS already overrides it to.
- Default new-config name base is "Setup" (used as "Setup 1" etc.).

Internal function names, HTML comments, and console logs keep "controller" since they're developer-facing.