### PR TITLE
Make Edit a borderless blue text link on saved-config cards

### DIFF
--- a/setup.html
+++ b/setup.html
@@ -884,24 +884,20 @@ noindex: true
         justify-content: flex-end;
         flex-wrap: wrap;
     }
-    .config-card-icon-btn {
-        display: inline-flex;
-        align-items: center;
-        justify-content: center;
-        width: 36px;
-        height: 36px;
-        padding: 0;
-        background: white;
-        border: 1px solid #d0d7de;
-        border-radius: 6px;
-        color: #555;
+    .config-card-edit-link {
+        align-self: center;
+        padding: 6px 10px;
+        background: transparent;
+        border: none;
+        color: #1e90ff;
+        font-size: 1.4rem;
+        font-family: inherit;
         cursor: pointer;
-        transition: background 0.15s, border-color 0.15s, color 0.15s;
+        transition: color 0.15s;
     }
-    .config-card-icon-btn:hover {
-        background: #f4f6f8;
-        border-color: #b8c1cc;
-        color: #1a1a2e;
+    .config-card-edit-link:hover {
+        color: #1873cc;
+        text-decoration: underline;
     }
 
     /* Searchable map combobox */
@@ -2453,9 +2449,7 @@ function renderConfigCard(config, index, mode) {
     html += renderConfigDetails(cfg, uniqueId, false, true);
     html += '</div>';
     html += '<div class="config-card-actions">';
-    html += '<button class="config-card-icon-btn" onclick="event.stopPropagation(); editConfiguration(' + index + ')" title="Edit" aria-label="Edit">';
-    html += '<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 20h9"></path><path d="M16.5 3.5a2.121 2.121 0 0 1 3 3L7 19l-4 1 1-4 12.5-12.5z"></path></svg>';
-    html += '</button>';
+    html += '<button class="config-card-edit-link" onclick="event.stopPropagation(); editConfiguration(' + index + ')">Edit</button>';
     if (mode === 'activation') {
         html += '<button class="setup-btn setup-btn-primary" onclick="event.stopPropagation(); introSelectConfig(' + index + ')">Select</button>';
     }


### PR DESCRIPTION
Side-by-side icon + primary button felt visually mismatched next to the Select CTA. Swap the pencil-icon button for a plain "Edit" text button (transparent background, blue #1e90ff, underline on hover) so the Select button stays the clear call to action and Edit reads as secondary.