### PR TITLE
CalTopo Access URL + blue outlines on setup sections

### DIFF
--- a/caltopo.html
+++ b/caltopo.html
@@ -53,7 +53,7 @@ noindex: true
     }
     .ct-container {
         width: 92%;
-        max-width: 900px;
+        max-width: 1000px;
         margin: 0 auto;
         padding: 1rem 1rem 4rem;
     }
@@ -286,6 +286,18 @@ noindex: true
         </div>
     </div>
 
+    <!-- Step 3: Access URL (optional) -->
+    <div class="ct-section">
+        <h2>Step 3: Access URL <span style="font-weight: 400; color: #888;">(optional)</span></h2>
+        <p style="font-size: 1.4rem; color: #333; margin: 0 0 0.75rem; line-height: 1.6;">Paste a CalTopo Access URL to unlock CalTopo's drone integration. Your drone appears on the shared CalTopo map with its live position, heading, altitude, and camera field of view — and anyone following along in CalTopo can click the drone's pin to watch the Eagle Eyes livestream for it, right from the map.</p>
+        <p style="font-size: 1.35rem; color: #777; margin: 0 0 1rem;"><strong>Where to find it:</strong> in CalTopo, open the admin menu &rarr; <strong>Trackable Devices</strong> &rarr; <strong>Create new Access URL</strong>, then paste it here.</p>
+        <div class="ct-field">
+            <label for="ctAccessUrl">Access URL</label>
+            <input type="text" id="ctAccessUrl" placeholder="Paste the Access URL from CalTopo" autocomplete="off">
+            <p style="font-size: 1.2rem; color: #888; margin: 0.4rem 0 0;">Double-check the paste &mdash; we can't verify this automatically yet.</p>
+        </div>
+    </div>
+
     <!-- Verify button -->
     <div style="text-align: center; margin-bottom: 2rem;">
         <p style="font-size: 1.35rem; color: #777; margin-bottom: 1rem;">Once all three credential fields are filled, press the button below to verify the credentials.</p>
@@ -296,7 +308,7 @@ noindex: true
     <!-- Result (hidden until verify succeeds) -->
     <div id="ctResult" style="display: none;">
         <div class="ct-section">
-            <h2>Step 3: Transfer CalTopo Service Account to Eagle Eyes</h2>
+            <h2>Step 4: Transfer CalTopo Service Account to Eagle Eyes</h2>
             <div class="ct-success-box" id="ctVerifiedBox" style="margin-bottom: 1rem;"></div>
             <p style="font-size: 1.4rem; color: #333; margin-bottom: 1.5rem; line-height: 1.6;">Follow the instructions below to transfer the credentials to Eagle Eyes, depending on whether you started this process from a mobile device or from this computer.</p>
 
@@ -392,10 +404,22 @@ noindex: true
         el.className = 'ct-status ' + type;
     }
 
+    // Strip a known CalTopo tracking-URL prefix if the user pasted the full URL
+    // instead of the bare token. No other validation — the token itself can be
+    // any user-renamable string, so we never reject.
+    function normalizeAccessUrl(raw) {
+        var v = (raw || '').trim();
+        if (!v) return '';
+        return v.replace(/^https?:\/\/(preview\.)?caltopo\.com\/t\//i, '');
+    }
+
     window.ctVerify = async function() {
         var accountId = document.getElementById('ctAccountId').value.trim();
         var credentialId = document.getElementById('ctCredentialId').value.trim();
         var secretKey = document.getElementById('ctSecret').value.trim();
+        var accessUrl = normalizeAccessUrl(document.getElementById('ctAccessUrl').value);
+        // Normalize back into the field so the user sees what we're sending
+        document.getElementById('ctAccessUrl').value = accessUrl;
         var btn = document.getElementById('ctVerifyBtn');
 
         // Validate secret format
@@ -435,14 +459,16 @@ noindex: true
         }
 
         try {
+            var verifyBody = {
+                account_id: accountId,
+                credential_id: credentialId,
+                credential_secret: secretKey
+            };
+            if (accessUrl) verifyBody.access_url = accessUrl;
             var resp = await fetch(API_BASE + 'verify_caltopo_service_account', {
                 method: 'POST',
                 headers: headers,
-                body: JSON.stringify({
-                    account_id: accountId,
-                    credential_id: credentialId,
-                    credential_secret: secretKey
-                })
+                body: JSON.stringify(verifyBody)
             });
 
             if (resp.status === 429) {
@@ -479,7 +505,8 @@ noindex: true
                 teamName: result.team_name || '',
                 accountId: accountId,
                 credentialId: credentialId,
-                secretKey: secretKey
+                secretKey: secretKey,
+                accessUrl: accessUrl
             };
 
             renderSuccess(verifiedData);
@@ -499,12 +526,14 @@ noindex: true
         if (data.permission) html += '<div class="ct-detail-row"><span class="label">Permission:</span><span>' + escapeHtml(data.permission) + '</span></div>';
         box.innerHTML = html;
 
-        var payload = JSON.stringify({
+        var payloadObj = {
             type: 'mirada-caltopo-service-account',
             accountId: data.accountId,
             credentialId: data.credentialId,
             secretKey: data.secretKey
-        });
+        };
+        if (data.accessUrl) payloadObj.accessUrl = data.accessUrl;
+        var payload = JSON.stringify(payloadObj);
 
         var qrBox = document.getElementById('ctQrBox');
         qrBox.innerHTML = '';
@@ -533,12 +562,14 @@ noindex: true
 
     window.ctDownloadJson = function() {
         if (!verifiedData) return;
-        var payload = JSON.stringify({
+        var payloadObj = {
             type: 'mirada-caltopo-service-account',
             accountId: verifiedData.accountId,
             credentialId: verifiedData.credentialId,
             secretKey: verifiedData.secretKey
-        }, null, 2);
+        };
+        if (verifiedData.accessUrl) payloadObj.accessUrl = verifiedData.accessUrl;
+        var payload = JSON.stringify(payloadObj, null, 2);
         var blob = new Blob([payload], { type: 'application/json' });
         var url = URL.createObjectURL(blob);
         var a = document.createElement('a');

--- a/setup.html
+++ b/setup.html
@@ -142,24 +142,30 @@ noindex: true
         gap: 0.75rem;
         padding: 1rem 1.25rem;
         background: #f8f9fa;
-        border: 1px solid #e9ecef;
+        border: 1px solid #c4ddf7;
         border-radius: 4px;
         cursor: pointer;
         margin-bottom: 1.5rem;
-        transition: background 0.2s, border-color 0.2s;
+        transition: background 0.2s, border-color 0.2s, box-shadow 0.2s;
         user-select: none;
     }
     .optional-toggle:hover {
-        background: #eef1f4;
-        border-color: #dee2e6;
+        background: #eef4fc;
+        border-color: #a0c8f0;
     }
     .optional-toggle.active {
         background: #f0f7ff;
-        border-color: #b3d4fc;
+        border-color: #1e90ff;
+        box-shadow: inset 0 0 0 1px #1e90ff;
     }
     .optional-toggle.filled {
         background: #f0faf2;
         border-color: #a8dab5;
+    }
+    .optional-toggle.filled.active {
+        background: #f0f7ff;
+        border-color: #1e90ff;
+        box-shadow: inset 0 0 0 1px #1e90ff;
     }
     .optional-toggle .toggle-status {
         width: 22px;

--- a/setup.html
+++ b/setup.html
@@ -3638,8 +3638,9 @@ function buildCaltopoServiceAccountJson() {
         teamAccountId: (caltopoVerifiedData && caltopoVerifiedData.teamAccountId) || '',
         teamName: (caltopoVerifiedData && caltopoVerifiedData.teamName) || ''
     };
-    // Per backend convention: store access_url (snake_case), and only when non-empty
-    if (accessUrl) obj.access_url = accessUrl;
+    // Store accessUrl (camelCase) to match the surrounding service_account
+    // fields; only when non-empty per omit-when-absent convention.
+    if (accessUrl) obj.accessUrl = accessUrl;
     return JSON.stringify(obj);
 }
 

--- a/setup.html
+++ b/setup.html
@@ -1494,6 +1494,12 @@ noindex: true
                         <input type="text" id="ctCredentialId" placeholder="e.g. Q9NVD150H92L" maxlength="12" style="text-transform: uppercase;">
                     </div>
                 </div>
+                <div class="setup-field" style="margin-top: 1rem;">
+                    <label for="ctAccessUrl">Access URL <span style="font-weight: 400; color: #888;">(optional)</span></label>
+                    <p style="font-size: 1.25rem; color: #777; margin: 0 0 0.4rem; line-height: 1.5;">Unlocks CalTopo's drone integration — your drone appears on the shared map with its live position, heading, altitude, and camera field of view, and viewers can click the drone's pin to watch the Eagle Eyes livestream.</p>
+                    <input type="text" id="ctAccessUrl" placeholder="Paste the Access URL from CalTopo" autocomplete="off">
+                    <p style="font-size: 1.2rem; color: #888; margin: 0.3rem 0 0;">From CalTopo: admin menu &rarr; Trackable Devices &rarr; Create new Access URL. We can't auto-verify it yet, so double-check the paste.</p>
+                </div>
                 <div class="form-step-actions">
                     <button class="setup-btn setup-btn-primary" id="ctVerifyBtn" onclick="verifyCaltopoServiceAccount()" disabled>Verify &amp; Connect</button>
                     <a href="#" class="back-link" onclick="showCtSubStep(3); return false;">Back</a>
@@ -3164,6 +3170,8 @@ function handleCtPasteField() {
             document.getElementById('ctAccountId').value = data.accountId;
             document.getElementById('ctCredentialId').value = data.credentialId;
             document.getElementById('ctKey').value = data.secretKey;
+            var ctAccessUrlEl = document.getElementById('ctAccessUrl');
+            if (ctAccessUrlEl) ctAccessUrlEl.value = data.accessUrl || data.access_url || '';
             ['ctAccountId','ctCredentialId','ctKey'].forEach(function(id) {
                 document.getElementById(id).dispatchEvent(new Event('input', { bubbles: true }));
             });
@@ -3192,12 +3200,15 @@ async function applyCaltopoCredentials(payload) {
     toggle.querySelector('[style*="flex: 1"]').appendChild(loadingEl);
 
     try {
-        var result = await apiCall('verify_caltopo_service_account', {
+        var pasteAccessUrl = normalizeAccessUrl(payload.accessUrl || payload.access_url || '');
+        var verifyBody = {
             license_id: currentLicenseId,
             account_id: payload.accountId,
             credential_id: payload.credentialId,
             credential_secret: payload.secretKey
-        });
+        };
+        if (pasteAccessUrl) verifyBody.access_url = pasteAccessUrl;
+        var result = await apiCall('verify_caltopo_service_account', verifyBody);
 
         if (!result.success) throw new Error('Verification failed');
 
@@ -3255,6 +3266,8 @@ async function ctRefreshMaps() {
     var accountId = document.getElementById('ctAccountId').value.trim();
     var credentialId = document.getElementById('ctCredentialId').value.trim();
     var key = document.getElementById('ctKey').value.trim();
+    var accessUrlEl = document.getElementById('ctAccessUrl');
+    var accessUrl = accessUrlEl ? normalizeAccessUrl(accessUrlEl.value) : '';
     if (!accountId || !credentialId || !key) return;
 
     var spinner = document.getElementById('ctSummaryMapSpinner');
@@ -3266,12 +3279,14 @@ async function ctRefreshMaps() {
     if (trigger) trigger.disabled = true;
 
     try {
-        var result = await apiCall('verify_caltopo_service_account', {
+        var refreshBody = {
             license_id: currentLicenseId,
             account_id: accountId,
             credential_id: credentialId,
             credential_secret: key
-        });
+        };
+        if (accessUrl) refreshBody.access_url = accessUrl;
+        var result = await apiCall('verify_caltopo_service_account', refreshBody);
 
         if (result.success) {
             caltopoVerifiedData.title = result.title || caltopoVerifiedData.title;
@@ -3595,11 +3610,22 @@ function handleCaltopoQrPayload(text) {
     applyCaltopoCredentials(payload);
 }
 
+// Strip a known CalTopo tracking-URL prefix if the user pasted the full URL
+// instead of the bare token. No other validation — tokens can be any
+// user-renamable string, so we never reject.
+function normalizeAccessUrl(raw) {
+    var v = (raw || '').trim();
+    if (!v) return '';
+    return v.replace(/^https?:\/\/(preview\.)?caltopo\.com\/t\//i, '');
+}
+
 // Build CalTopo service account JSON from form fields + verified data
 function buildCaltopoServiceAccountJson() {
     var accountId = document.getElementById('ctAccountId').value.trim();
     var credentialId = document.getElementById('ctCredentialId').value.trim();
     var key = document.getElementById('ctKey').value.trim();
+    var accessUrlEl = document.getElementById('ctAccessUrl');
+    var accessUrl = accessUrlEl ? normalizeAccessUrl(accessUrlEl.value) : '';
     // If no key fields are filled, return empty string
     if (!accountId && !credentialId && !key) return '';
     var obj = {
@@ -3612,6 +3638,8 @@ function buildCaltopoServiceAccountJson() {
         teamAccountId: (caltopoVerifiedData && caltopoVerifiedData.teamAccountId) || '',
         teamName: (caltopoVerifiedData && caltopoVerifiedData.teamName) || ''
     };
+    // Per backend convention: store access_url (snake_case), and only when non-empty
+    if (accessUrl) obj.access_url = accessUrl;
     return JSON.stringify(obj);
 }
 
@@ -3620,6 +3648,9 @@ async function verifyCaltopoServiceAccount() {
     var accountId = document.getElementById('ctAccountId').value.trim();
     var credentialId = document.getElementById('ctCredentialId').value.trim();
     var key = document.getElementById('ctKey').value.trim();
+    var accessUrlEl = document.getElementById('ctAccessUrl');
+    var accessUrl = accessUrlEl ? normalizeAccessUrl(accessUrlEl.value) : '';
+    if (accessUrlEl) accessUrlEl.value = accessUrl;
     var resultEl = document.getElementById('ctVerifyResult');
     var btn = document.getElementById('ctVerifyBtn');
 
@@ -3635,12 +3666,14 @@ async function verifyCaltopoServiceAccount() {
     resultEl.style.display = 'none';
 
     try {
-        var result = await apiCall('verify_caltopo_service_account', {
+        var verifyBody = {
             license_id: currentLicenseId,
             account_id: accountId,
             credential_id: credentialId,
             credential_secret: key
-        });
+        };
+        if (accessUrl) verifyBody.access_url = accessUrl;
+        var result = await apiCall('verify_caltopo_service_account', verifyBody);
 
         if (result.success) {
             var permission = result.permission || '';
@@ -3785,6 +3818,9 @@ function populateForm(config) {
         document.getElementById('ctAccountId').value = sa.accountId || '';
         document.getElementById('ctCredentialId').value = sa.credentialId || '';
         document.getElementById('ctKey').value = sa.key || '';
+        var ctAccessUrlEl = document.getElementById('ctAccessUrl');
+        // Defensive: accept either snake_case (backend-preferred) or camelCase
+        if (ctAccessUrlEl) ctAccessUrlEl.value = sa.access_url || sa.accessUrl || '';
         // Store metadata from saved config so it's included on save
         caltopoVerifiedData = {
             title: sa.title || '',
@@ -3822,6 +3858,8 @@ function clearForm() {
     document.getElementById('ctAccountId').value = '';
     document.getElementById('ctCredentialId').value = '';
     document.getElementById('ctKey').value = '';
+    var ctAccessUrlEl = document.getElementById('ctAccessUrl');
+    if (ctAccessUrlEl) ctAccessUrlEl.value = '';
     caltopoVerifiedData = null;
     var ctResult = document.getElementById('ctVerifyResult');
     ctResult.className = 'caltopo-verify-result';


### PR DESCRIPTION
## Summary

- **CalTopo Access URL (optional)** — new paste field in both `caltopo.html` (dedicated Step 3; Transfer panel renumbered to Step 4) and `setup.html`'s inline CalTopo form. Unlocks CalTopo's drone integration: the drone shows up on the shared CalTopo map with its live position, heading, altitude, and camera field of view, and viewers can click the pin to watch the Eagle Eyes livestream for that drone. Plumbed through `verify_caltopo_service_account` (as `access_url`, omitted when blank), into the saved-config object as `service_account.accessUrl` (camelCase, to match surrounding keys — confirmed with backend), and into the QR / paste / JSON transfer payload as `accessUrl` so the mobile app picks it up. No format validation — tokens are user-renamable in the CalTopo admin portal — only a URL-prefix strip for `https://(preview.)?caltopo.com/t/`. Helper copy under the field says "we can't verify this automatically yet" until the backend adds `access_url_valid`.
- **Blue outlines on `.optional-toggle` sections** — the grey `#e9ecef` border washes out on phones held in direct sun, making it hard to tell where one setting ends or which one is being edited. Default / hover / active / filled / filled+active states all move to a blue palette (default `#c4ddf7`, active full `#1e90ff` with an inset box-shadow so edit mode reads as thicker without a layout shift). Filled-but-not-editing keeps its green "done" cue; a new `.filled.active` rule ensures blue wins when a filled setting is also being edited (previously the filled green silently won due to rule order). Saved-config cards (`.config-card-toggle`) inherit the same palette automatically.

## Test plan

- [ ] `caltopo.html`: open the page, fill all three credentials; Access URL blank → Verify & Connect sends the existing three fields with no `access_url` in the body. Repeat with an Access URL pasted (both the bare token and the full `https://caltopo.com/t/<token>` URL) and confirm the body carries `access_url` and the field shows the normalized token after Verify.
- [ ] `caltopo.html`: after a successful verify, confirm the generated QR code, the paste-code textarea, and the JSON download all include `accessUrl` when set, and omit the key when blank.
- [ ] `setup.html` inline form: same coverage — verify with and without Access URL; paste the code from caltopo.html and confirm the Access URL auto-populates; save and reload the config and confirm the value round-trips.
- [ ] `setup.html` inline form: inspect the `save_or_update_configuration` request body — when set, `config.service_account.accessUrl` (camelCase) is present; when blank, the key is absent.
- [ ] `setup.html` setup form: each of the three accordion sections (Units, CalTopo, Procedures) shows a thin blue outline when collapsed; expanding turns the outline into a stronger blue wrapping the whole expanded panel; filling a value and collapsing shows green; expanding a filled section shows blue (not green).
- [ ] Activation intro cards + management list: same blue/green treatment carries over via `.config-card-toggle`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)