### PR TITLE
Flag Access URL as NEW in caltopo.html Step 3

### DIFF
--- a/caltopo.html
+++ b/caltopo.html
@@ -288,7 +288,7 @@ noindex: true
 
     <!-- Step 3: Access URL (optional) -->
     <div class="ct-section">
-        <h2>Step 3: Access URL <span style="font-weight: 400; color: #888;">(optional)</span></h2>
+        <h2>Step 3: Access URL <span style="font-weight: 400; color: #888;">(optional)</span> <span style="display: inline-block; background: #1e90ff; color: white; font-size: 1.1rem; font-weight: 600; padding: 2px 8px; border-radius: 10px; margin-left: 4px; vertical-align: middle; letter-spacing: 0.3px;">NEW</span></h2>
         <p style="font-size: 1.4rem; color: #333; margin: 0 0 0.75rem; line-height: 1.6;">Paste a CalTopo Access URL to unlock CalTopo's dedicated drone integration. Your drone appears on the shared CalTopo map with its live position, heading, altitude, and camera field of view — and anyone following along in CalTopo can click the drone's pin to watch the Eagle Eyes livestream for it, right from the map.</p>
         <p style="font-size: 1.35rem; color: #777; margin: 0 0 1rem;"><strong>Where to find it:</strong> in CalTopo, open the admin menu &rarr; <strong>Trackable Devices</strong> &rarr; <strong>Create new Access URL</strong>, then paste it here.</p>
         <div class="ct-field">


### PR DESCRIPTION
## Summary

Follow-up to #292 (which added the blue "NEW" pill next to the Access URL label in `setup.html`'s edit summary panel). Adds the same pill to `caltopo.html` **Step 3: Access URL (optional)** heading so returning users who land on caltopo.html to regenerate credentials also see the drone integration is a new capability, not just another renumbered step.

## Test plan

- [ ] Open `/caltopo/` → confirm the blue "NEW" pill appears to the right of "Step 3: Access URL (optional)" in the section heading.
- [ ] Verify pill styling matches the one in `setup.html`'s edit summary panel (same colour, same rounded shape).

🤖 Generated with [Claude Code](https://claude.com/claude-code)