### PR TITLE
Fix Access URL chip overflow; recency-sort diagnostics

### DIFF
--- a/setup.html
+++ b/setup.html
@@ -3335,6 +3335,7 @@ async function ctRefreshMaps() {
     var key = document.getElementById('ctKey').value.trim();
     var accessUrlEl = document.getElementById('ctAccessUrl');
     var accessUrl = accessUrlEl ? normalizeAccessUrl(accessUrlEl.value) : '';
+    console.log('[ctRefreshMaps] entry:', { hasAccount: !!accountId, hasCred: !!credentialId, hasKey: !!key, hasLicense: !!currentLicenseId });
     if (!accountId || !credentialId || !key) return;
 
     var spinner = document.getElementById('ctSummaryMapSpinner');
@@ -3501,20 +3502,28 @@ function ctMapRecency(m) {
         var v = m[CT_MAP_RECENCY_CANDIDATES[i]];
         if (v == null) continue;
         var t = typeof v === 'number' ? v : Date.parse(v);
-        if (!isNaN(t)) return t;
+        if (isNaN(t)) continue;
+        // Normalize epoch seconds to ms if it looks like seconds-since-1970
+        if (t > 0 && t < 1e12) t = t * 1000;
+        return t;
     }
     return 0;
 }
 
 // One-time diagnostic: log the keys of the first loaded map so we can see
 // which timestamp field CalTopo actually returns, and narrow the helper above
-// once confirmed. Fires once per page load.
+// once confirmed. Always fires once per page load, even if maps is empty.
 var _ctMapShapeLogged = false;
 function ctLogMapShapeOnce(maps) {
-    if (_ctMapShapeLogged || !maps || !maps.length) return;
+    if (_ctMapShapeLogged) return;
     _ctMapShapeLogged = true;
-    var sample = maps[0];
     try {
+        console.log('[CalTopo maps] loaded count:', maps ? maps.length : 0);
+        if (!maps || !maps.length) {
+            console.log('[CalTopo maps] (no maps to sample)');
+            return;
+        }
+        var sample = maps[0];
         console.log('[CalTopo maps] sample keys:', Object.keys(sample));
         console.log('[CalTopo maps] sample:', sample);
         var found = null;
@@ -3524,8 +3533,10 @@ function ctLogMapShapeOnce(maps) {
                 break;
             }
         }
-        console.log('[CalTopo maps] recency field matched:', found || '(none — sort will fall back to name)');
-    } catch (e) {}
+        console.log('[CalTopo maps] recency field matched:', found || '(none — sort falls back to alphabetical)');
+    } catch (e) {
+        console.log('[CalTopo maps] log error:', e);
+    }
 }
 
 function ctMapComboFilter(query) {

--- a/setup.html
+++ b/setup.html
@@ -908,8 +908,8 @@ noindex: true
 
     /* Access URL chip (filled-state view in the CalTopo edit summary) */
     .access-url-chip {
-        display: inline-flex;
-        align-items: center;
+        flex: 1;
+        min-width: 0;
         padding: 6px 10px;
         background: #e8f4ff;
         border: 1px solid #b3d4fc;
@@ -917,7 +917,6 @@ noindex: true
         font-family: monospace;
         font-size: 1.3rem;
         color: #1a1a2e;
-        max-width: calc(100% - 36px);
         overflow: hidden;
         text-overflow: ellipsis;
         white-space: nowrap;
@@ -1417,7 +1416,7 @@ noindex: true
                             <div style="font-size: 1.1rem; color: #888; margin-top: 0.3rem;">Double-check the paste &mdash; we can't verify this automatically yet.</div>
                         </div>
                         <div id="ctAccessUrlFilledMode" style="display: none; align-items: center; gap: 0.4rem;">
-                            <span class="access-url-chip" id="ctAccessUrlChip"></span>
+                            <span class="access-url-chip" id="ctAccessUrlChip" title=""></span>
                             <button type="button" class="access-url-clear" onclick="clearAccessUrlFromSummary()" aria-label="Remove access URL" title="Remove">&times;</button>
                         </div>
                     </div>
@@ -3295,6 +3294,7 @@ async function applyCaltopoCredentials(payload) {
             teamName: result.team_name || '',
             maps: result.maps || []
         };
+        ctLogMapShapeOnce(caltopoVerifiedData.maps);
 
         // Populate the main map dropdown
         populateMapDropdown(caltopoVerifiedData.maps);
@@ -3361,6 +3361,7 @@ async function ctRefreshMaps() {
             caltopoVerifiedData.teamAccountId = result.team_account_id || caltopoVerifiedData.teamAccountId;
             caltopoVerifiedData.teamName = result.team_name || caltopoVerifiedData.teamName;
             caltopoVerifiedData.maps = result.maps || [];
+            ctLogMapShapeOnce(caltopoVerifiedData.maps);
 
             populateMapDropdown(caltopoVerifiedData.maps);
             ctMapComboPopulate();
@@ -3485,18 +3486,46 @@ function ctMapComboScore(query, name) {
 }
 
 // Return a timestamp in ms for sorting; 0 if no recognizable recency field
-// is present on the map. The exact field name from CalTopo's verify response
-// isn't locked in from the backend yet, so try the common shapes.
+// is present on the map. CalTopo's verify response shape isn't locked in, so
+// try both snake_case and camelCase variants.
+var CT_MAP_RECENCY_CANDIDATES = [
+    'updated', 'updated_at', 'updatedAt', 'lastUpdated', 'lastUpdate', 'updateTime',
+    'modified', 'modified_at', 'modifiedAt', 'last_modified', 'lastModified',
+    'accessed', 'last_accessed', 'lastAccessed', 'accessedAt',
+    'created', 'created_at', 'createdAt', 'createTime',
+    'timestamp', 'time', 'date'
+];
 function ctMapRecency(m) {
     if (!m) return 0;
-    var candidates = ['updated', 'updated_at', 'modified', 'last_modified', 'accessed', 'last_accessed', 'timestamp'];
-    for (var i = 0; i < candidates.length; i++) {
-        var v = m[candidates[i]];
+    for (var i = 0; i < CT_MAP_RECENCY_CANDIDATES.length; i++) {
+        var v = m[CT_MAP_RECENCY_CANDIDATES[i]];
         if (v == null) continue;
         var t = typeof v === 'number' ? v : Date.parse(v);
         if (!isNaN(t)) return t;
     }
     return 0;
+}
+
+// One-time diagnostic: log the keys of the first loaded map so we can see
+// which timestamp field CalTopo actually returns, and narrow the helper above
+// once confirmed. Fires once per page load.
+var _ctMapShapeLogged = false;
+function ctLogMapShapeOnce(maps) {
+    if (_ctMapShapeLogged || !maps || !maps.length) return;
+    _ctMapShapeLogged = true;
+    var sample = maps[0];
+    try {
+        console.log('[CalTopo maps] sample keys:', Object.keys(sample));
+        console.log('[CalTopo maps] sample:', sample);
+        var found = null;
+        for (var i = 0; i < CT_MAP_RECENCY_CANDIDATES.length; i++) {
+            if (sample[CT_MAP_RECENCY_CANDIDATES[i]] != null) {
+                found = CT_MAP_RECENCY_CANDIDATES[i];
+                break;
+            }
+        }
+        console.log('[CalTopo maps] recency field matched:', found || '(none — sort will fall back to name)');
+    } catch (e) {}
 }
 
 function ctMapComboFilter(query) {
@@ -3716,8 +3745,11 @@ function renderAccessUrlSummaryMode() {
     var value = ctAccessUrlEl ? ctAccessUrlEl.value.trim() : '';
     if (value) {
         var chip = document.getElementById('ctAccessUrlChip');
-        if (chip) chip.textContent = value;
-        filledMode.style.display = 'inline-flex';
+        if (chip) {
+            chip.textContent = value;
+            chip.title = value;
+        }
+        filledMode.style.display = 'flex';
         emptyMode.style.display = 'none';
         var summaryInput = document.getElementById('ctAccessUrlSummaryInput');
         if (summaryInput) summaryInput.value = '';
@@ -3821,6 +3853,7 @@ async function verifyCaltopoServiceAccount() {
                 teamName: result.team_name || '',
                 maps: result.maps || []
             };
+            ctLogMapShapeOnce(caltopoVerifiedData.maps);
             showCaltopoVerifySuccess(caltopoVerifiedData);
             populateMapDropdown(caltopoVerifiedData.maps);
             // Advance to map selection sub-step


### PR DESCRIPTION
## Summary

- **Access URL chip overflow fix.** Inside `inline-flex`, `max-width: calc(100% - 36px)` resolved against an auto-sized parent so long tokens pushed out of the box. Switched the filled-mode container to block `display: flex`, gave the chip `flex: 1; min-width: 0` so it shrinks to fit, and let `text-overflow: ellipsis` handle truncation. Added a `title` attribute with the full value for hover.
- **Recency-sort diagnostics + epoch-seconds handling.** The map list in the default-map picker is still sorting alphabetically, meaning none of my candidate timestamp field names match what CalTopo actually returns. Two things added to narrow this down on the next browser reload:
  - `ctMapRecency` now normalizes values that look like epoch seconds (`< 1e12`) into milliseconds, so a numeric `updated: 1745123456` doesn't just sort adjacent to strings.
  - Verbose one-shot logging from `ctRefreshMaps` (entry log showing which credentials are present) and `ctLogMapShapeOnce` (always fires once per page load, logging map count + sample keys + matched field). Diagnostic-only — removed once we've seen the real field name in the console.

## Test plan

- [ ] Edit a saved CalTopo config with a long access URL already set → confirm the chip truncates with `…` inside the panel and hover shows the full value.
- [ ] Hard-refresh setup.html (Cmd+Shift+R), open a saved config's CalTopo section, open DevTools → Console → expect `[ctRefreshMaps] entry: …` and `[CalTopo maps] sample keys: […]` lines. The matched field name in the console tells us which candidate worked, or confirms none did.
- [ ] Once the real field name is known, follow-up PR narrows the helper to that single key and removes the diagnostic logs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)