### PR TITLE
CalTopo foldout polish: drop duplicate blurb, shrink copy, clear focus

### DIFF
--- a/setup.html
+++ b/setup.html
@@ -1404,9 +1404,9 @@ noindex: true
                 <!-- Folds out inside the same container when checked: no account yet -->
                 <div id="ctNoAccount" style="display: none; margin-top: 1rem; padding-top: 0.75rem; border-top: 1px solid #dee2e6;" onclick="event.stopPropagation();">
                     <div>
-                        <p style="font-size: 1.5rem; color: #333; margin: 0 0 0.75rem; line-height: 1.6;">Keep this page open and open a browser on your desktop or laptop. Go to:</p>
-                        <div style="margin-bottom: 0.75rem;"><a href="{{ '/caltopo/' | relative_url }}" target="_blank" style="color: #1e90ff; text-decoration: none; font-weight: 700; font-size: 1.7rem;">EagleEyesSearch.com/caltopo</a></div>
-                        <p style="font-size: 1.5rem; color: #333; margin: 0 0 1rem; line-height: 1.6;">After completing the form you will see a QR code. You can then scan the QR code using this mobile device:</p>
+                        <p style="font-size: 1.3rem; color: #333; margin: 0 0 0.5rem; line-height: 1.6;">Keep this page open and open a browser on your desktop or laptop. Go to:</p>
+                        <div style="margin-bottom: 0.75rem;"><a href="{{ '/caltopo/' | relative_url }}" target="_blank" style="color: #1e90ff; text-decoration: none; font-weight: 700; font-size: 1.5rem;">EagleEyesSearch.com/caltopo</a></div>
+                        <p style="font-size: 1.3rem; color: #333; margin: 0 0 0.75rem; line-height: 1.6;">After completing the form you will see a QR code. You can then scan the QR code using this mobile device:</p>
                         <div>
                             <button class="setup-btn setup-btn-primary" onclick="openCaltopoQrScanner()" style="width: 100%; max-width: 320px;">Scan QR Code</button>
                         </div>
@@ -1415,7 +1415,7 @@ noindex: true
                             <a href="#" id="ctDesktopPasteToggle" onclick="ctShowDesktopPaste(); return false;" style="color: #888; font-size: 1.3rem; text-decoration: underline;">Can't scan a QR code?</a>
 
                             <div id="ctDesktopPaste" style="display: none; margin-top: 0.75rem;">
-                                <p style="font-size: 1.4rem; color: #333; margin: 0 0 0.75rem; line-height: 1.6;">Completing the form on <a href="{{ '/caltopo/' | relative_url }}" target="_blank" style="color: #1e90ff; text-decoration: none; font-weight: 600;">eagleeyessearch.com/caltopo</a> also generates a code. Click the <strong>Copy code</strong> button there, then paste it below.</p>
+                                <p style="font-size: 1.3rem; color: #333; margin: 0 0 0.75rem; line-height: 1.6;">Completing the form on <a href="{{ '/caltopo/' | relative_url }}" target="_blank" style="color: #1e90ff; text-decoration: none; font-weight: 600;">eagleeyessearch.com/caltopo</a> also generates a code. Click the <strong>Copy code</strong> button there, then paste it below.</p>
                                 <div style="display: flex; gap: 0.5rem; margin-bottom: 0.5rem;">
                                     <input type="text" id="ctPasteField" readonly placeholder="Click Paste to fill" style="flex: 1; padding: 10px 12px; border: 1px solid #dee2e6; border-radius: 4px; font-size: 1.3rem; font-family: monospace; background: #fafbfc;">
                                     <button onclick="ctPasteFromClipboard()" style="white-space: nowrap; padding: 10px 16px; background: #e9ecef; color: #333; border: none; border-radius: 4px; font-size: 1.4rem; font-weight: 500; cursor: pointer; transition: all 0.2s;" onmousedown="this.style.background='#1e90ff'; this.style.color='white';" onmouseup="this.style.background='#e9ecef'; this.style.color='#333';" onmouseleave="this.style.background='#e9ecef'; this.style.color='#333';">Paste</button>
@@ -3679,6 +3679,12 @@ function showCtChangeFlow() {
     var noAccountEl = document.getElementById('ctNoAccount');
     if (summaryEl) summaryEl.style.display = 'none';
     if (noAccountEl) noAccountEl.style.display = 'block';
+    // Clear any lingering focus so the first button in the revealed panel
+    // doesn't render in :focus state (blue primary button can read as grey
+    // on some browsers with the default focus overlay).
+    if (document.activeElement && typeof document.activeElement.blur === 'function') {
+        document.activeElement.blur();
+    }
 }
 
 // Update the CalTopo toggle's description so it's obvious at a glance whether

--- a/setup.html
+++ b/setup.html
@@ -1403,8 +1403,6 @@ noindex: true
 
                 <!-- Folds out inside the same container when checked: no account yet -->
                 <div id="ctNoAccount" style="display: none; margin-top: 1rem; padding-top: 0.75rem; border-top: 1px solid #dee2e6;" onclick="event.stopPropagation();">
-                    <p style="font-size: 1.5rem; color: #333; margin: 0 0 1rem; line-height: 1.6;">A CalTopo service account stays signed in for you, so you don't have to log in manually every few days.</p>
-
                     <div>
                         <p style="font-size: 1.5rem; color: #333; margin: 0 0 0.75rem; line-height: 1.6;">Keep this page open and open a browser on your desktop or laptop. Go to:</p>
                         <div style="margin-bottom: 0.75rem;"><a href="{{ '/caltopo/' | relative_url }}" target="_blank" style="color: #1e90ff; text-decoration: none; font-weight: 700; font-size: 1.7rem;">EagleEyesSearch.com/caltopo</a></div>


### PR DESCRIPTION
## Summary

Follow-ups after the change-service-account flow went live:

- **Drop duplicate blurb.** The foldout led with *"A CalTopo service account stays signed in for you, so you don't have to log in manually every few days"* — the same rationale the CalTopo toggle description already carries (*"Not connected — set up to stay signed in to CalTopo without re-authenticating every few days"*). Removed from the foldout so the change-flow starts straight at the actionable instructions.
- **Shrink foldout text.** Foldout paragraphs were rendering at 1.5rem with a 1.7rem headline link, noticeably chunkier than the rest of the form. Scale paragraphs to 1.3rem (matches helper-text density) and the EagleEyesSearch.com headline link to 1.5rem (still prominent, no longer shouty).
- **Clear focus on swap.** `showCtChangeFlow()` was leaving focus on the just-clicked "Change service account →" link, which in turn left the newly-visible **Scan QR Code** primary button rendering in a `:focus` state that reads as a washed-out grey on some browsers. Blur the active element after swapping panels so nothing in the revealed foldout starts pre-selected.

## Test plan

- [ ] Edit a config with a connected CalTopo account. Expand the CalTopo section → confirm the summary is clean. Click **Change service account →**.
- [ ] Foldout appears with *"Keep this page open and open a browser on your desktop or laptop. Go to:"* → bold **EagleEyesSearch.com/caltopo** link → *"After completing the form you will see a QR code..."* → blue **Scan QR Code** button. No duplicate "stays signed in" blurb at the top.
- [ ] Text density in the foldout matches the rest of the form — no giant paragraphs.
- [ ] The Scan QR Code button renders as a clean primary blue with crisp white text (not greyed-out from focus).
- [ ] Collapse + re-expand the CalTopo section — flips back to the connected summary (escape hatch still works).

🤖 Generated with [Claude Code](https://claude.com/claude-code)