### PR TITLE
Restore CalTopo service-account rationale to the main toggle

### DIFF
--- a/setup.html
+++ b/setup.html
@@ -1366,7 +1366,8 @@ noindex: true
             <div class="toggle-status">&#10003;</div>
             <div style="flex: 1;">
                 <div class="toggle-label">CalTopo Service Account</div>
-                <div class="toggle-desc" id="ctToggleDesc">Not connected — set up to stay signed in to CalTopo without re-authenticating every few days</div>
+                <div class="toggle-desc">Stay signed in to CalTopo without re-authenticating every few days.</div>
+                <div class="toggle-desc" id="ctToggleStatus" style="margin-top: 0.3rem; font-size: 1.25rem;">Not connected — tap to set up</div>
 
                 <!-- Folds out inside the same container when checked: existing account -->
                 <div id="ctExistingSummary" style="display: none; margin-top: 1rem; padding-top: 0.75rem; border-top: 1px solid #dee2e6;" onclick="event.stopPropagation();">
@@ -3691,16 +3692,17 @@ function showCtChangeFlow() {
 // a service account is set up (instead of a generic benefit statement that
 // looks the same in both states).
 function renderCtToggleState() {
-    var desc = document.getElementById('ctToggleDesc');
-    if (!desc) return;
+    var statusEl = document.getElementById('ctToggleStatus');
+    if (!statusEl) return;
     var connected = !!(caltopoVerifiedData && (caltopoVerifiedData.title || caltopoVerifiedData.teamName));
     if (!connected) {
         var acctId = (document.getElementById('ctAccountId') || {}).value;
         connected = !!acctId;
     }
-    desc.textContent = connected
+    statusEl.textContent = connected
         ? 'Connected — tap to view or change'
-        : 'Not connected — set up to stay signed in to CalTopo without re-authenticating every few days';
+        : 'Not connected — tap to set up';
+    statusEl.style.color = connected ? '#1e8e3e' : '#c77700';
 }
 
 // Build CalTopo service account JSON from form fields + verified data


### PR DESCRIPTION
## Summary

Follow-up to the foldout cleanup in #299 — removing the "A CalTopo service account stays signed in for you…" blurb left the main toggle without any explanation of what a service account is or why a user should set one up. Previously the toggle description was state-dependent (only said "stay signed in…" when disconnected; once connected it read "tap to view or change"), so connected users lost the rationale entirely.

Restructure the toggle body:

- **Static rationale** as the primary description: *"Stay signed in to CalTopo without re-authenticating every few days."* Always visible regardless of state.
- **Secondary status line** below it, colour-coded:
  - *"Not connected — tap to set up"* in amber (`#c77700`) when no account is connected.
  - *"Connected — tap to view or change"* in green (`#1e8e3e`) when set up.

`renderCtToggleState()` now targets a dedicated `#ctToggleStatus` span (not the whole description), so the rationale stays untouched while the status flips.

## Test plan

- [ ] Open a saved config with **no CalTopo account**: toggle shows "Stay signed in to CalTopo…" above an amber "Not connected — tap to set up" line.
- [ ] Open a saved config with a **connected** CalTopo account: same rationale, but the status line reads green "Connected — tap to view or change".
- [ ] Complete a fresh QR/paste setup or Change flow — status line flips from amber to green without the rationale disappearing.
- [ ] Clear the form (create-new) — status resets to amber "Not connected — tap to set up".

🤖 Generated with [Claude Code](https://claude.com/claude-code)