### PR TITLE
Show all licenses from get_license_overview; log raw response

### DIFF
--- a/setup.html
+++ b/setup.html
@@ -2001,18 +2001,17 @@ async function lpLoadUserLicenses() {
                 headers: { 'Authorization': 'Bearer ' + token }
             });
             if (!resp.ok) throw new Error('Failed to load licenses (HTTP ' + resp.status + ')');
-            var overview = ((await resp.json()).overview) || [];
-            var nowMs = Date.now();
+            var overviewJson = await resp.json();
+            console.log('get_license_overview response:', overviewJson);
+            var overview = (overviewJson && overviewJson.overview) || [];
             lpUserLicenses = overview
-                .filter(function(o) {
-                    return o && o.license_id && o.expiry_date &&
-                        new Date(o.expiry_date).getTime() >= nowMs;
-                })
+                .filter(function(o) { return o && o.license_id; })
                 .map(function(o) {
+                    var expMs = o.expiry_date ? new Date(o.expiry_date).getTime() : NaN;
                     return {
                         license_id: o.license_id,
                         license_name: o.license_name || '',
-                        expiry_timestamp: Math.floor(new Date(o.expiry_date).getTime() / 1000),
+                        expiry_timestamp: isNaN(expMs) ? null : Math.floor(expMs / 1000),
                         n_tokens: o.total_keys || 0,
                         remaining_keys: Math.max(0, o.keys_left || 0),
                         has_existing_key: false


### PR DESCRIPTION
- Drop the "must have future expiry" filter from the management-flow license mapping. account.html shows both active and expired licenses; dropping expired ones entirely risks showing "No licenses found" when the user has a just-expired or near-expiry license we shouldn't be hiding.
- Tolerate missing/malformed expiry_date (store expiry_timestamp null when the date doesn't parse; lpRenderPrimary already handles null by rendering "No expiry").
- Log the raw get_license_overview response to the console so we can diagnose when the picker shows "No active licenses found" for a user who actually has licenses.