### PR TITLE
Add "Before you start" prerequisites to top of /caltopo

### DIFF
--- a/caltopo.html
+++ b/caltopo.html
@@ -454,6 +454,32 @@ noindex: true
         margin-top: 1px;
     }
     .ct-caution strong { color: #6a4700; }
+    .ct-preflight {
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        flex-wrap: wrap;
+        gap: 0.4rem 0.9rem;
+        margin: 1rem auto 0;
+        max-width: 720px;
+        font-size: 1.3rem;
+        color: #4a4a4a;
+        text-align: center;
+    }
+    .ct-preflight-item {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.4rem;
+    }
+    .ct-preflight-icon {
+        width: 16px;
+        height: 16px;
+        stroke: #555;
+        flex-shrink: 0;
+    }
+    .ct-preflight-sep {
+        color: #bbb;
+    }
     .ct-reveal-wrap { position: relative; }
     .ct-reveal-cover {
         position: absolute;
@@ -536,6 +562,24 @@ noindex: true
     <div class="ct-header">
         <h1>Eagle Eyes ↔ CalTopo</h1>
         <p>Create a CalTopo service account so Eagle Eyes apps can stay permanently connected to CalTopo without needing to log in again.</p>
+        <p class="ct-preflight">
+            <span class="ct-preflight-item">
+                <svg class="ct-preflight-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                    <rect x="2" y="4" width="20" height="13" rx="2"/>
+                    <path d="M8 21h8"/>
+                    <path d="M12 17v4"/>
+                </svg>
+                Open on a laptop or desktop
+            </span>
+            <span class="ct-preflight-sep" aria-hidden="true">&middot;</span>
+            <span class="ct-preflight-item">
+                <svg class="ct-preflight-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                    <path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2"/>
+                    <circle cx="12" cy="7" r="4"/>
+                </svg>
+                Admin access in CalTopo required
+            </span>
+        </p>
         <div class="ct-caution">
             <svg class="ct-caution-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
                 <path d="M10.29 3.86 1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"/>


### PR DESCRIPTION
Two prerequisites silently broke the flow for users who didn't meet them: opening the page on mobile (CalTopo's Administer screens and our multi-field form are awkward on small screens) and lacking team-admin access in CalTopo (only admins see the "Administer" menu that the Step 1 breadcrumb depends on).

Insert a compact one-line "ct-preflight" row between the subtitle and the existing yellow caution box. Two icon-led chips — monitor + "Open on a laptop or desktop", person + "Admin access in CalTopo required" — separated by a middot, wrapping on narrow screens. Adds one scannable line of lighter grey text without displacing the security caution below.