### PR TITLE
Clear add_license form fields after successful submission

### DIFF
--- a/add_license.html
+++ b/add_license.html
@@ -178,7 +178,7 @@ permalink: /add_license/
                     </div> -->
                     <div class="form-section" style="width: 80%;">
                         <label for="emails"><b>Emails:</b></label>
-                        <textarea id="emails" name="emails" rows="2" placeholder="joe@example.com"></textarea>
+                        <textarea id="emails" name="emails" rows="2" placeholder="joe@example.com" autocomplete="off"></textarea>
                         <div class="help-text" style="font-size: 0.7em; color: #555; margin-top: 5px; font-style: italic;">Will default to info@eagleeyessearch.com when public license is selected</div>
                     </div>
                     <div class="form-section">
@@ -563,6 +563,13 @@ permalink: /add_license/
 
                         statusSpan.html(statusMessage).removeClass('error-box info-box').addClass('success-box');
                         scrollToStatus();
+
+                        // Clear recipient-specific fields after a successful submission so the
+                        // next user/license processed in the same browser session starts fresh.
+                        $('#emails').val('');
+                        $('#license_name').val('');
+                        $('#domains').val('');
+                        $('#trialRequestId').val('');
                     } catch (error) {
                         console.error("Error parsing response:", error);
                         statusSpan.html('<div class="success-box"><strong>✓ User Status Updated Successfully</strong></div>').removeClass('error-box info-box').addClass('success-box');
@@ -639,6 +646,16 @@ permalink: /add_license/
 
                         statusSpan.html(licenseDataDisplay).removeClass('error-box info-box').addClass('success-box');
                         scrollToStatus();
+
+                        // Clear recipient-specific fields after a successful submission so the
+                        // next trial/license created in the same browser session starts fresh.
+                        // Prevents "stale emails carried over from previous submission" bug
+                        // (which historically created trial licenses with the wrong recipient
+                        // emails because admins processing batches didn't notice the carry-over).
+                        $('#emails').val('');
+                        $('#license_name').val('');
+                        $('#domains').val('');
+                        $('#trialRequestId').val('');
                     } catch (error) {
                         console.error("Error parsing license data:", error);
                         statusSpan.html('<div class="error-box"><strong>✗ Error Displaying License Information</strong><p>License may have been created but there was an error displaying it. Please check the console for details.</p></div>').removeClass('success-box info-box').addClass('error-box');


### PR DESCRIPTION
When admins process trial requests in batches in the same browser tab, the recipient-specific fields (emails, license_name, domains, trial_request_id) were carrying over from one submission to the next. This caused trial licenses to be created with stale emails from a previous trial — historically resulting in ~20 trial licenses with the wrong recipient emails (e.g. "Trial license for Tim Coombs" with emails set to a previous admin's team).

Two changes:
- autocomplete="off" on the emails textarea so the browser doesn't suggest previously-submitted values.
- Clear emails / license_name / domains / trial_request_id after a successful submission (in both the create-license and update-user-status flows) so the next license created in the same session starts fresh.