### PR TITLE
Add mirada/map/ SPA entry so /mirada/map URL works

### DIFF
--- a/mirada/map/index.html
+++ b/mirada/map/index.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en" class="dark">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="icon" type="image/png" href="/mirada/logo.png" />
+    <meta name="theme-color" content="#000000" />
+    <meta
+      name="description"
+      content="Web site created using create-tsrouter-app"
+    />
+    <link rel="apple-touch-icon" href="/mirada/logo192.png" />
+    <link rel="manifest" href="/mirada/manifest.json" />
+    <title>Eagle Eyes Mirada</title>
+    <!-- <meta
+      http-equiv="Content-Security-Policy"
+      content="default-src 'self'; style-src 'self' 'unsafe-inline'; script-src 'self';"
+    /> --> <!-- TODO: Adjust CSP as needed -->
+    <script type="module" crossorigin src="/mirada/assets/index-DSW_r7pf.js"></script>
+    <link rel="stylesheet" crossorigin href="/mirada/assets/index-CbcSF8ZQ.css">
+  </head>
+  <body>
+    <div id="app"></div>
+  </body>
+</html>


### PR DESCRIPTION
## Summary                                                                                                                              
                                                                                                                                          
  Adds `mirada/map/index.html` as a duplicate of `mirada/index.html` so that visiting `eagleeyessearch.com/mirada/map` directly serves the
   Mirada SPA instead of returning a 404.                                                                                                 
                                                               
  ## Why                                                                                                                                  
                                          
  GitHub Pages serves static files only — it doesn't do SPA-style fallback. Today, `mirada/index.html` is the only file at the `mirada/`  
  path, so:                                                                                                                               
   
  - ✅ `eagleeyessearch.com/mirada/` → serves the SPA                                                                                     
  - ❌ `eagleeyessearch.com/mirada/map` → 404 (no `mirada/map/index.html` exists)
                                                                                                                                          
  This PR creates `mirada/map/index.html` as a copy of `mirada/index.html`, which makes both URLs serve the SPA. Once the matching scan2v2
   PR ships (separate, follow-up), the SPA will detect the `/map` pathname and open with the map full-screen and the media viewer
  collapsed.                                                                                                                              
                                                                                                                                          
  ## Risk                                                                                                                                 
                                                                                                                                          
  Very low. This is purely additive — no existing file is modified.
                                          
  - Asset references inside `mirada/index.html` are absolute (`/mirada/assets/...`), so the duplicate file resolves all assets correctly
  without modification.                                                                                                                   
  - `eagleeyessearch.com/mirada/` keeps working unchanged.
  - Every existing `/mirada/#/...` deep link keeps working unchanged.                                                                     
  - No build / Jekyll config changes.                          
                                                                                                                                          
  ## Transient state until scan2v2 PR ships                                                                                               
                                                                                                                                          
  Until the matching scan2v2 PR is merged + deployed via `deploy-web.sh`, hitting `eagleeyessearch.com/mirada/map` will load the SPA but  
  behave the same as `eagleeyessearch.com/mirada/` (no map-fullscreen, normal case auto-load). That's a benign no-op state, not a         
  regression.                                                                                                                             
                                                                                                                                          
  ## Note for future deploys                                   
                                                                                                                                          
  `scan2v2/deploy-web.sh` does `rm -rf $TARGET_DIR/mirada` before copying fresh build output, which would wipe `mirada/map/index.html`.
  The follow-up scan2v2 PR will update that script to recreate `mirada/map/index.html` on every deploy so this file stays in place.

  ## Test plan                                                                                                                            
   
  - [ ] After deploy, visit `https://www.eagleeyessearch.com/mirada/map` and verify the SPA loads (page shows the Mirada UI rather than a 
  404)                                                         
  - [ ] Visit `https://www.eagleeyessearch.com/mirada/` and verify it still loads normally
  - [ ] Visit an existing hash-deep-link like `https://www.eagleeyessearch.com/mirada/#/?ch=...` and verify it still works    