### PR TITLE
Disclose anonymous analytics in floating question widget

### DIFF
--- a/_includes/floating-button.html
+++ b/_includes/floating-button.html
@@ -144,7 +144,12 @@
         font-size: 12px;
         color: #666;
         margin-top: 8px;
+        margin-bottom: 0;
         line-height: 1.4;
+    }
+
+    .question-subtitle + .question-subtitle {
+        margin-top: 4px;
     }
 
     /* Mobile responsive */
@@ -206,6 +211,7 @@
                 required
             ></textarea>
             <p class="question-subtitle">You will be directed to the best-matching answers in our FAQ, and to our contact email.</p>
+            <p class="question-subtitle">We collect anonymous usage data from this widget to help improve our FAQs.</p>
             <button type="submit" class="submit-question-btn">Submit Question</button>
         </form>
     </div>


### PR DESCRIPTION
## Summary
  - Adds a one-line disclosure under the floating "Ask a question" widget so users know
  their submission sends anonymous data to our analytics (matches the disclosure pattern
   from `/downloads` and `/livestream`).
  - Tightens `.question-subtitle` margins so consecutive subtitles sit at ~4px apart
  instead of the default `<p>` margin gap.

  ## What users see
  When the floating question button is expanded, a second line of small grey text
  appears below the existing "You will be directed to..." subtitle:

  > *We collect anonymous usage data from this widget to help improve our FAQs.*
  
  ## Files changed
  - `_includes/floating-button.html` — adds the disclosure line + adjacent-sibling
  margin rule

  ## Scope note
  This PR does **not** touch `/mirada/`. The Mirada SPA bundle refresh (with consent
  overlay + page-view analytics) will land in a separate PR when the web build is
  published.

  ## Test plan
  - [ ] Open any page with the floating question button → expand it → see the new
  disclosure line tightly under the existing "You will be directed to..." line
  - [ ] Submit a question → confirm row still posts to the FAQ analytics sheet (no
  regression)