### PR TITLE
ADS-B plane orientation + Canadian chip/dot rendering & click fixes

### DIFF
--- a/drone-map.html
+++ b/drone-map.html
@@ -5061,7 +5061,20 @@
                     pointToLayer: function(feature, latlng) {
                         var sev = (feature.properties && feature.properties.severity) || 'low';
                         var s = notamStyle[sev] || notamStyle.low;
-                        return L.circleMarker(latlng, { radius: s.r, color: s.color, fillColor: s.color, fillOpacity: 0.75, weight: 1 });
+                        // Solid colored fill (severity colour) with a white outline so the
+                        // dot reads cleanly against both dark and light basemaps.
+                        var m = L.circleMarker(latlng, {
+                            radius: s.r,
+                            color: '#fff',
+                            weight: 1.5,
+                            fillColor: s.color,
+                            fillOpacity: 0.85
+                        });
+                        m.on('click', function(ev) {
+                            L.DomEvent.stopPropagation(ev);
+                            handleCanadianMapClick(m.getLatLng(), ev.originalEvent);
+                        });
+                        return m;
                     }
                 }),
                 buildPopup: function(p) {
@@ -5092,14 +5105,20 @@
                 layer: L.geoJSON(null, {
                     pointToLayer: function(feature, latlng) {
                         var p = feature.properties || {};
-                        var cat = p.category || 'VFR';
-                        var color = metarColors[cat] || '#2563eb';
+                        // Color encodes flight category; label always says METAR for
+                        // clarity regardless of category quality / missing fields.
+                        var color = metarColors[p.category] || '#2563eb';
                         var icon = L.divIcon({
                             className: 'can-metar-chip',
-                            html: '<div style="background:' + color + ';color:#fff;border:1px solid #fff;border-radius:3px;padding:1px 5px;font:11px sans-serif;font-weight:600;box-shadow:0 1px 3px rgba(0,0,0,0.5);white-space:nowrap;">' + cat + '</div>',
-                            iconSize: null, iconAnchor: [40, 8]
+                            html: '<div style="background:' + color + ';color:#fff;border:1px solid #fff;border-radius:3px;padding:1px 5px;font:11px sans-serif;font-weight:600;box-shadow:0 1px 3px rgba(0,0,0,0.5);white-space:nowrap;">METAR</div>',
+                            iconSize: null, iconAnchor: [44, 8]
                         });
-                        return L.marker(latlng, { icon: icon, interactive: true });
+                        var m = L.marker(latlng, { icon: icon, interactive: true });
+                        m.on('click', function(ev) {
+                            L.DomEvent.stopPropagation(ev);
+                            handleCanadianMapClick(m.getLatLng(), ev.originalEvent);
+                        });
+                        return m;
                     }
                 }),
                 buildPopup: function(p) {
@@ -5186,7 +5205,12 @@
                             html: '<div style="background:#0ea5e9;color:#fff;border:1px solid #fff;border-radius:3px;padding:1px 5px;font:11px sans-serif;font-weight:600;box-shadow:0 1px 3px rgba(0,0,0,0.5);white-space:nowrap;">TAF</div>',
                             iconSize: null, iconAnchor: [-12, 8]
                         });
-                        return L.marker(latlng, { icon: icon, interactive: true });
+                        var m = L.marker(latlng, { icon: icon, interactive: true });
+                        m.on('click', function(ev) {
+                            L.DomEvent.stopPropagation(ev);
+                            handleCanadianMapClick(m.getLatLng(), ev.originalEvent);
+                        });
+                        return m;
                     }
                 }),
                 buildPopup: function(p) {
@@ -5311,19 +5335,24 @@
             };
         }
 
-        // Build a simple plane marker — small Unicode glyph rotated to track.
+        // Inline SVG plane that points straight up at rotation 0. Track is degrees
+        // from north (0=N, 90=E), so rotating this upward-facing icon clockwise by
+        // the track produces the correct visual heading on screen — no font-
+        // dependent glyph orientation to compensate for.
+        var ADSB_LOL_PLANE_SVG = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="18" height="18">'
+            + '<path d="M16 2 L18 13 L29 18 L29 21 L18 18.5 L18 25 L20 27 L20 29 L16 28 L12 29 L12 27 L14 25 L14 18.5 L3 21 L3 18 L14 13 Z" '
+            + 'fill="#22d3ee" stroke="#000" stroke-width="0.6" stroke-linejoin="round" paint-order="stroke" />'
+            + '</svg>';
         function buildAdsbLolMarker(ac) {
             var lat = ac.lat, lon = ac.lon;
             if (typeof lat !== 'number' || typeof lon !== 'number') return null;
             var track = (typeof ac.track === 'number') ? ac.track : 0;
             var callsign = (ac.flight || ac.r || ac.hex || '').toString().trim();
-            // Tiny ✈ marker. Unicode plane points "up-right" at 45°, so subtract 45 to align
-            // 0° (north) with the glyph's perceived heading.
             var icon = L.divIcon({
                 className: 'adsb-lol-marker',
-                html: '<div style="transform:rotate(' + (track - 45) + 'deg);font-size:14px;color:#22d3ee;text-shadow:0 0 3px #000,0 0 1px #000;line-height:1;">✈</div>',
-                iconSize: [16, 16],
-                iconAnchor: [8, 8]
+                html: '<div style="transform:rotate(' + track + 'deg);transform-origin:center;width:18px;height:18px;line-height:0;">' + ADSB_LOL_PLANE_SVG + '</div>',
+                iconSize: [18, 18],
+                iconAnchor: [9, 9]
             });
             var marker = L.marker([lat, lon], { icon: icon, title: callsign, interactive: true });
             marker.bindPopup(buildAdsbLolPopup(ac));


### PR DESCRIPTION
## Summary
  Three small marker-rendering fixes to layers shipped in #316:

  - **Live ADS-B plane icons** now orient correctly to flight track (heading north →
  nose points up).
  - **METAR chips** label as "METAR" instead of the raw flight-category code (which read
   as "VFR" or "??").
  - **NOTAM dots** get a white outline for visibility on both basemaps.
  - **METAR / TAF / NOTAM markers click reliably** — clicking anywhere on the chip or
  dot now opens the unified popup at the marker's lat/lng.

  ## Detail
  
  ### ADS-B plane orientation
  Previous version used the Unicode ✈ glyph with a hard-coded `-45°` offset to
  compensate for the glyph's default tilt. Per-font behaviour made this unreliable — the
   user was seeing planes rendered tilted sideways regardless of heading.

  Replaced with an inline SVG plane that points straight up at rotation 0. Track
  rotation now maps directly to screen heading; track=0 (north) → nose up, track=90
  (east) → nose right, etc.
  
  ### METAR chip label
  The chip previously displayed the raw `category` field from the METAR (`VFR`, `MVFR`,
  `IFR`, `LIFR`), which:
  - Didn't communicate that the chip was a METAR
  - Showed `??` when the category was missing or malformed in the upstream feed

  Now the chip always reads "METAR"; the chip background colour still encodes the flight
   category for visual scanning.

  ### NOTAM outline
  NOTAMs remain colored dots (avoiding the clutter that 1,800+ "NOTAM" chips across
  Canada would create). Added a 1.5 px white outline so the dots read cleanly against
  both dark and light basemaps.

  ### Click reliability
  The unified Canadian-Drone-Layers click handler uses an 18 px screen-distance hit-test
   for point markers. That broke for chip-style markers because their `iconAnchor`
  offset (~40 px) puts the visible chip well outside the hit-test radius — clicking the
  chip didn't register as clicking the marker.
  
  Each of `metars`, `tafs`, and `notams` now attaches a per-marker click handler that:
  1. Calls `L.DomEvent.stopPropagation(ev)` so the map click handler doesn't fire
  afterward and close the popup
  2. Calls `handleCanadianMapClick(marker.getLatLng(), ev.originalEvent)` — same unified
   popup path as everything else, just keyed to the marker's lat/lng instead of the
  cursor's screen position

  ## Files changed
  - `drone-map.html` (+42 / −13)

  ## Test plan
  - [ ] Toggle Live ADS-B (adsb.lol) on → planes orient correctly to heading (sanity
  check: aircraft on final approach to YVR runway 26R should point ~west)
  - [ ] Toggle Canadian Drone Layers + METARs on → all visible chips read "METAR",
  coloured by category (green VFR, blue MVFR, red IFR, purple LIFR)
  - [ ] Click a METAR chip anywhere on the chip → popup opens with the proper METAR info
  - [ ] Click a TAF chip → popup opens
  - [ ] Click a NOTAM dot → popup opens; dots are visible against both Dark and Light
  themes
  - [ ] Stacked-popup cycling still works in overlapping areas